### PR TITLE
Dpm 1939 add fp fn metrics to benchmark with graceful fallback support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ rezultati/
 weights/
 report_examples/
 trump/
+chinese-test/
+chinese-test-60s/
+chinese-test-combined/
+report_baseline_replacement/
 CHANGELOG_DPM-1576.md
 CODE_EXPLANATION.md
 benchmark.md

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ metrics_testing_samples/
 checkpoints/
 audio_processed/
 samples-148/
+<<<<<<< Updated upstream
 rezultati/
 weights/
 report_examples/
@@ -43,6 +44,10 @@ report_baseline_replacement/
 CHANGELOG_DPM-1576.md
 CODE_EXPLANATION.md
 benchmark.md
+=======
+trump/
+weights/
+>>>>>>> Stashed changes
 
 
 report/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ Open-source benchmarking framework for evaluating audio watermarking robustness.
 - **Plugin-based**: Models and attacks auto-discovered from `src/plugins/models/` and `src/plugins/attacks/` via `PluginManager`
 - **Client-server**: Complex ML models/attacks run in Docker containers, accessed via HTTP (FastAPI). Simple attacks run natively
 - **Base classes**: `BaseModel` (embed/detect) in `src/core/base_model.py`, `BaseAttack` (apply) in `src/core/base_attack.py`
-- **Config-driven**: Each plugin has a `config.json` with defaults. Model configs include `returns_confidence` and `is_zero_bit` flags for dispatch
+- **Config-driven**: Each plugin has a `config.json` with defaults. Model configs include `returns_confidence` and `is_zero_bit` flags. Detection reliability uses `is_watermarked()` on the model class
 
 ## Key Files
 
@@ -43,7 +43,7 @@ python src/run.py --wav_files_dir /path/to/wavs --wm_model AudioSealModel --atta
 ## Development Conventions
 
 - **Attack parameter names must be unique across all attacks** — they share a flat CLI namespace. Suffix with attack name (e.g., `snr_db_replay`, `order_bandstop`). The system warns on collisions but doesn't prevent them
-- **Model capabilities declared in config.json** — use `returns_confidence: true/false` and `is_zero_bit: true/false` instead of hardcoding model names in benchmark.py
+- **Model capabilities declared in config.json** — use `returns_confidence: true/false` and `is_zero_bit: true/false` for general dispatch. For detection reliability, models must implement `is_watermarked(detect_output) -> bool` in `model.py`
 - **Native attacks** need only `attack.py` + `config.json` in their directory
 - **Dockerized attacks/models** additionally need `app.py`, `Dockerfile`, `requirements.txt`
 - **Use `logger` not `print()`** for all output. Use `logging.getLogger(__name__)` (never overwrite the `logging` module)

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ If NISQA is not installed or the weights file is missing, the metric is silently
 
 ### 4. Detection Reliability (Optional)
 
-Use `--detection_reliability` to measure false positive and false negative rates. This mode supports a **single model** per run (zero-bit or confidence-based).
+Use `--detection_reliability` to measure false positive and false negative rates. This mode supports a **single model** per run and requires the model to implement `is_watermarked()` (see [Adding a New Watermarking Model](#adding-a-new-watermarking-model)).
 
 ```bash
 python src/run.py --wav_files_dir /path/to/audio \
@@ -255,6 +255,12 @@ python src/run.py --wav_files_dir /path/to/audio \
 ```
 
 Results are saved to `report/detection_reliability.json` and a dedicated `detection_reliability_report.pdf` is generated.
+
+> **Note:** Only models that implement `is_watermarked()` support this mode.
+> Each model defines its own detection logic — zero-bit models check the
+> binary output directly, while confidence-based models compare against a
+> threshold. If a model does not implement this method, a clear error is
+> raised at runtime.
 
 ### 5. Save Audio (Optional)
 
@@ -367,7 +373,21 @@ class NewModel(BaseModel):
     def detect(self, audio: np.ndarray, sampling_rate: int) -> np.ndarray:
         """Detects watermark from the audio."""
         return np.random.randint(0, 2, size=16)
+
+    def is_watermarked(self, detect_output) -> bool:
+        """Decide whether a watermark is present based on detect() output.
+
+        Required for --detection_reliability support. Each model defines
+        its own logic here. Examples:
+          - Zero-bit model: return bool(detect_output)
+          - Confidence model: return confidence >= threshold
+        """
+        return bool(np.any(detect_output))
 ```
+
+> **`is_watermarked()` is optional** — only needed if you want the model to
+> support `--detection_reliability`. Models without it work normally in the
+> standard benchmark mode.
 
 3.	Add config.json
 ```json

--- a/README.md
+++ b/README.md
@@ -231,7 +231,51 @@ If NISQA is not installed or the weights file is missing, the metric is silently
 > instructions at https://github.com/google/visqol and install the
 > resulting Python package into the same environment.
 
-### 4. View Results
+### 4. Detection Reliability (Optional)
+
+Use `--detection_reliability` to measure false positive and false negative rates. This mode supports a **single model** per run (zero-bit or confidence-based).
+
+```bash
+python src/run.py --wav_files_dir /path/to/audio \
+                  --wm_model PerthModel \
+                  --detection_reliability
+```
+
+Without attacks the mode measures:
+- **False positive**: detection on clean (unwatermarked) audio reports a watermark present.
+- **False negative**: detection on watermarked audio fails to find the watermark.
+
+When combined with `--attack_types` or `--attack_groups`, FP/FN are additionally reported per attack (attack applied to clean audio for FP, attack applied to watermarked audio for FN).
+
+```bash
+python src/run.py --wav_files_dir /path/to/audio \
+                  --wm_model AudioSealModel \
+                  --detection_reliability \
+                  --attack_types GaussianNoiseAttack LowpassFilterAttack
+```
+
+Results are saved to `report/detection_reliability.json` and a dedicated `detection_reliability_report.pdf` is generated.
+
+### 5. Save Audio (Optional)
+
+Use `--save_audio` to write intermediate audio files to disk for manual inspection. Files are saved to `<report_dir>/audio/`.
+
+```bash
+python src/run.py --wav_files_dir /path/to/audio \
+                  --wm_model AudioSealModel \
+                  --detection_reliability \
+                  --attack_types GaussianNoiseAttack \
+                  --save_audio
+```
+
+In detection reliability mode the following files are saved per input file:
+- `{filename}_watermarked.wav` — watermarked audio (before any attack)
+- `{filename}_{AttackName}_clean.wav` — attack applied to the clean (unwatermarked) audio
+- `{filename}_{AttackName}.wav` — attack applied to the watermarked audio
+
+In the standard benchmark mode, watermarked and attacked-watermarked files are saved.
+
+### 6. View Results
 
 The benchmark generates the following outputs in the `report/` directory:
 

--- a/src/core/base_model.py
+++ b/src/core/base_model.py
@@ -115,6 +115,18 @@ class BaseModel(abc.ABC):
         """
         pass
 
+    def is_watermarked(self, detect_output) -> bool:
+        """Determine whether a watermark is present based on detect() output.
+
+        Models that support --detection_reliability must override this method.
+        The default implementation raises NotImplementedError so that
+        detection_reliability can check support at runtime.
+        """
+        raise NotImplementedError(
+            f"{self.name} does not implement is_watermarked(). "
+            f"Cannot use --detection_reliability with this model."
+        )
+
     def generate_watermark(self) -> np.ndarray:
         """
         Generates a sample watermark.

--- a/src/plugins/models/audio_seal/config.json
+++ b/src/plugins/models/audio_seal/config.json
@@ -5,5 +5,6 @@
     "sampling_rate": 16000,
     "watermark_size": 16,
     "returns_confidence": true,
-    "is_zero_bit": false
+    "is_zero_bit": false,
+    "detection_threshold": 0.5
 }

--- a/src/plugins/models/audio_seal/model.py
+++ b/src/plugins/models/audio_seal/model.py
@@ -41,6 +41,12 @@ class AudioSealModel(BaseModel):
         
         return np.array(response_data["watermarked_audio"])
 
+    def is_watermarked(self, detect_output) -> bool:
+        """AudioSeal returns (watermark, confidence). Compare confidence to threshold."""
+        _watermark, confidence = detect_output
+        threshold = self._config.get("detection_threshold", 0.5)
+        return float(confidence) >= threshold
+
     def detect(self, audio: np.ndarray, sampling_rate: int) -> np.ndarray:
         """Detects a watermark in the audio using the AudioSeal service."""
         # Sanitize audio: replace NaN with 0 and clip Inf to valid float range

--- a/src/plugins/models/aware/config.json
+++ b/src/plugins/models/aware/config.json
@@ -5,5 +5,6 @@
     "sampling_rate": 16000,
     "watermark_size": 20,
     "returns_confidence": true,
-    "is_zero_bit": false
+    "is_zero_bit": false,
+    "detection_threshold": 0.5
 }

--- a/src/plugins/models/aware/model.py
+++ b/src/plugins/models/aware/model.py
@@ -47,6 +47,12 @@ class AwareModel(BaseModel):
 
         return np.array(response_data["watermarked_audio"])
 
+    def is_watermarked(self, detect_output) -> bool:
+        """AWARE returns (watermark, confidence). Compare confidence to threshold."""
+        _watermark, confidence = detect_output
+        threshold = self._config.get("detection_threshold", 0.5)
+        return float(confidence) >= threshold
+
     def detect(self, audio: np.ndarray, sampling_rate: int):
         """Detects a watermark in the audio using the AWARE service."""
         # Sanitize audio: replace NaN with 0 and clip Inf to valid float range

--- a/src/plugins/models/perth/model.py
+++ b/src/plugins/models/perth/model.py
@@ -37,6 +37,10 @@ class PerthModel(BaseModel):
         return np.array(response_data["watermarked_audio"])
     
     
+    def is_watermarked(self, detect_output) -> bool:
+        """Perth is zero-bit: detect returns 0 (not found) or 1 (found)."""
+        return bool(np.any(detect_output)) if detect_output is not None else False
+
     def detect(self, audio: np.ndarray, sampling_rate: int) -> np.ndarray:
         """Detects a watermark using the Perth service."""
         payload = {"audio": audio.tolist(), "sampling_rate": sampling_rate}

--- a/src/run.py
+++ b/src/run.py
@@ -139,6 +139,22 @@ def main():
     )
 
     parser.add_argument(
+        "--detection_reliability",
+        action="store_true",
+        default=False,
+        help=(
+            "Measure false positive (detection on clean audio) and false "
+            "negative (missed detection on watermarked audio) rates. "
+            "Currently supported only for zero-bit models and a single "
+            "model per run. Generates detection_reliability_report.pdf. "
+            "Combinable with --attack_types and --attack_groups: when "
+            "attacks are provided, FP/FN are also reported per attack "
+            "(attack applied to clean audio for FP, to watermarked audio "
+            "for FN)."
+        ),
+    )
+
+    parser.add_argument(
         "--save_audio",
         action="store_true",
         default=False,
@@ -209,6 +225,18 @@ def main():
         model_names = args.wm_models if args.wm_models else [args.wm_model]
         _clean_report_dir("report")
         run_no_attacks_mode(benchmark, filepaths, model_names, args)
+    elif args.detection_reliability:
+        # --- Detection reliability mode: FP/FN measurement ---
+        if args.wm_models and len(args.wm_models) > 1:
+            logger.error(
+                "--detection_reliability supports only a single model. "
+                "Use --wm_model instead of --wm_models, or pass exactly "
+                "one model name to --wm_models."
+            )
+            return
+        model_name = args.wm_models[0] if args.wm_models else args.wm_model
+        _clean_report_dir("report")
+        run_detection_reliability_mode(benchmark, filepaths, model_name, args)
     elif args.wm_models and len(args.wm_models) > 1:
         # --- Multi-model mode ---
         run_multiple_models(benchmark, filepaths, args.wm_models, args)
@@ -299,6 +327,73 @@ def run_no_attacks_mode(benchmark, filepaths, model_names, args):
 
     if not all_results:
         logger.error("No models completed successfully.")
+
+
+def run_detection_reliability_mode(benchmark, filepaths, model_name, args):
+    """Run the detection-reliability flow for a single zero-bit model.
+
+    Computes FP / FN both without attacks and (when attacks are
+    requested) with each attack applied, then writes a dedicated PDF
+    report. Lives in its own function so it doesn't clutter the
+    accuracy-driven ``run_single_model`` path.
+    """
+    from utils.detection_reliability import run_detection_reliability
+    from utils.detection_reliability_report_generator import (
+        generate_detection_reliability_report,
+    )
+
+    report_dir = "report"
+    os.makedirs(report_dir, exist_ok=True)
+
+    # Build the same ``args_dict`` plumbing the rest of the modes use --
+    # this is how attack-specific CLI overrides reach attack.apply().
+    args_dict = vars(args).copy()
+    # Drop keys that the orchestrator handles itself.
+    for key in (
+        "wm_model",
+        "wm_models",
+        "wav_files_dir",
+        "attack_types",
+        "attack_groups",
+        "no_attacks",
+        "detection_reliability",
+        "verbose",
+    ):
+        args_dict.pop(key, None)
+
+    attack_types = list(args.attack_types or [])
+
+    logger.info(
+        f"Running detection-reliability for {model_name} on "
+        f"{len(filepaths)} files; attacks={attack_types or 'none'}"
+    )
+    try:
+        result = run_detection_reliability(
+            benchmark,
+            filepaths,
+            wm_model=model_name,
+            attack_types=attack_types,
+            sampling_rate=None,
+            verbose=args.verbose,
+            **args_dict,
+        )
+    except ValueError as e:
+        logger.error(f"Detection reliability run failed: {e}")
+        return
+
+    # Persist raw result so later runs can inspect/regenerate the PDF.
+    result_path = os.path.join(report_dir, "detection_reliability.json")
+    with open(result_path, "w") as fp:
+        json.dump(to_json_safe(dict(result)), fp, indent=4)
+    logger.info(f"Detection reliability data saved to {result_path}")
+
+    try:
+        tex_path = generate_detection_reliability_report(
+            dict(result), report_dir=report_dir,
+        )
+        logger.info(f"Detection reliability report generated: {tex_path}")
+    except Exception as e:
+        logger.error(f"Failed to generate detection reliability report: {e}")
 
 
 def run_single_model(benchmark, filepaths, model_name, args, output_dir=None):

--- a/src/run.py
+++ b/src/run.py
@@ -145,8 +145,9 @@ def main():
         help=(
             "Measure false positive (detection on clean audio) and false "
             "negative (missed detection on watermarked audio) rates. "
-            "Currently supported only for zero-bit models and a single "
-            "model per run. Generates detection_reliability_report.pdf. "
+            "Supported for zero-bit models and confidence-based models "
+            "(using detection_threshold from config.json). Single model "
+            "per run. Generates detection_reliability_report.pdf. "
             "Combinable with --attack_types and --attack_groups: when "
             "attacks are provided, FP/FN are also reported per attack "
             "(attack applied to clean audio for FP, to watermarked audio "
@@ -220,7 +221,20 @@ def main():
         logger.error(f"Error accessing audio directory {args.wav_files_dir}: {e}")
         return
 
-    if args.no_attacks:
+    if args.no_attacks and args.detection_reliability:
+        # --- Combined mode: no-attacks baseline + FP/FN reliability ---
+        if args.wm_models and len(args.wm_models) > 1:
+            logger.error(
+                "--detection_reliability supports only a single model. "
+                "Use --wm_model instead of --wm_models, or pass exactly "
+                "one model name to --wm_models."
+            )
+            return
+        model_name = args.wm_models[0] if args.wm_models else args.wm_model
+        _clean_report_dir("report")
+        run_no_attacks_mode(benchmark, filepaths, [model_name], args)
+        run_detection_reliability_mode(benchmark, filepaths, model_name, args)
+    elif args.no_attacks:
         # --- No-attacks mode: embed + detect only ---
         model_names = args.wm_models if args.wm_models else [args.wm_model]
         _clean_report_dir("report")
@@ -330,12 +344,11 @@ def run_no_attacks_mode(benchmark, filepaths, model_names, args):
 
 
 def run_detection_reliability_mode(benchmark, filepaths, model_name, args):
-    """Run the detection-reliability flow for a single zero-bit model.
+    """Run detection-reliability for a single zero-bit or confidence-based model.
 
     Computes FP / FN both without attacks and (when attacks are
     requested) with each attack applied, then writes a dedicated PDF
-    report. Lives in its own function so it doesn't clutter the
-    accuracy-driven ``run_single_model`` path.
+    report.
     """
     from utils.detection_reliability import run_detection_reliability
     from utils.detection_reliability_report_generator import (
@@ -358,10 +371,18 @@ def run_detection_reliability_mode(benchmark, filepaths, model_name, args):
         "no_attacks",
         "detection_reliability",
         "verbose",
+        "calculate_quality_metrics",
+        "crop_before_attack",
+        "save_audio",
+        "output_dir",
     ):
         args_dict.pop(key, None)
 
     attack_types = list(args.attack_types or [])
+
+    audio_dir = None
+    if args.save_audio:
+        audio_dir = os.path.join(report_dir, "audio")
 
     logger.info(
         f"Running detection-reliability for {model_name} on "
@@ -375,6 +396,9 @@ def run_detection_reliability_mode(benchmark, filepaths, model_name, args):
             attack_types=attack_types,
             sampling_rate=None,
             verbose=args.verbose,
+            calculate_quality_metrics=args.calculate_quality_metrics,
+            save_audio=args.save_audio,
+            output_dir=audio_dir,
             **args_dict,
         )
     except ValueError as e:

--- a/src/utils/detection_reliability.py
+++ b/src/utils/detection_reliability.py
@@ -12,7 +12,7 @@ accuracy. The flow is:
     4. attack() on the watermarked audio, then detect() -> false_negative_with_attack
 
 Supports two model types:
-  - Zero-bit models (Perth, StariVigil): detect() returns binary 0/1.
+  - Zero-bit models (Perth): detect() returns binary 0/1.
   - Confidence-based models (AudioSeal, AWARE): detect() returns
     (watermark, confidence). Detection is positive when confidence
     exceeds the model's detection_threshold (set in config.json).
@@ -75,7 +75,7 @@ class DetectionReliabilityResult(dict):
 def _detect_is_positive_zero_bit(detect_output: Any) -> bool:
     """Return True when a zero-bit detector says 'watermark detected'.
 
-    Perth returns 0 or 1; StariVigil returns the same shape.
+    Perth returns 0 or 1.
     Accept either int or numpy array; treat any non-zero value as positive.
     """
     if isinstance(detect_output, np.ndarray):
@@ -268,6 +268,13 @@ def run_detection_reliability(
                     f"{filepath}: {e}. Skipping this attack for this file."
                 )
                 continue
+
+            if save_audio and output_dir:
+                base = os.path.splitext(os.path.basename(filepath))[0]
+                sf.write(
+                    os.path.join(output_dir, f"{base}_{attack_name}_clean.wav"),
+                    attacked_clean, sr,
+                )
 
             attack_state[attack_name]["fp_attempts"] += 1
             if _detect(model_instance, attacked_clean, sr, returns_confidence, detection_threshold):

--- a/src/utils/detection_reliability.py
+++ b/src/utils/detection_reliability.py
@@ -1,0 +1,304 @@
+"""Detection reliability — false positive / false negative measurements.
+
+Lives in its own module so the main benchmark loop stays focused on
+accuracy. The flow is:
+
+  Without attacks (always when --detection_reliability is set):
+    1. detect() on the clean audio                  -> false_positive_no_attack
+    2. embed() then detect() on watermarked         -> false_negative_no_attack
+
+  With attacks (only when at least one attack is provided):
+    3. attack() on the clean audio, then detect()   -> false_positive_with_attack
+    4. attack() on the watermarked audio, then detect() -> false_negative_with_attack
+
+Restricted to zero-bit models for now: those return a binary 0/1 from
+detect() so the FP/FN bookkeeping is unambiguous. Multi-bit models
+require a threshold on bit-accuracy that we don't want to bake in here.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+import numpy as np
+
+from utils.metrics import ALL_METRICS, compute_metrics
+from utils.utils import load_audio
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+class DetectionReliabilityResult(dict):
+    """Plain dict subclass; documents the expected shape.
+
+    Structure::
+
+        {
+            "model_name": str,
+            "is_zero_bit": True,
+            "n_files": int,
+            "no_attack": {
+                "false_positive_count": int,    # detected on clean audio
+                "false_negative_count": int,    # missed on watermarked audio
+            },
+            "attacks": {
+                attack_name: {
+                    "accuracy_mean": float,
+                    "always_on_metrics": {"pesq": float, "visqol": float, "stoi": float},
+                    "false_positive_count": int,
+                    "false_negative_count": int,
+                },
+                ...
+            },
+        }
+    """
+
+
+# ---------------------------------------------------------------------------
+# Detection helpers
+# ---------------------------------------------------------------------------
+
+def _detect_is_positive(detect_output: Any) -> bool:
+    """Return True when a zero-bit detector says 'watermark detected'.
+
+    Perth returns 0 or 1 (with ``round=True``) and StariVigil returns the
+    same shape; both collapse to a scalar after ``.item()`` / ``tolist()``.
+    Accept either int or numpy array; treat any non-zero value as positive.
+    """
+    if isinstance(detect_output, np.ndarray):
+        detect_output = detect_output.tolist()
+    if isinstance(detect_output, list):
+        # Some zero-bit models may return a single-element list.
+        return bool(detect_output[0]) if detect_output else False
+    return bool(detect_output)
+
+
+def _detect(model_instance, audio: np.ndarray, sampling_rate: int,
+            returns_confidence: bool) -> bool:
+    """Run detect() and reduce to a positive/negative boolean."""
+    if returns_confidence:
+        detected, _confidence = model_instance.detect(audio, sampling_rate)
+    else:
+        detected = model_instance.detect(audio, sampling_rate)
+    return _detect_is_positive(detected)
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+def run_detection_reliability(
+    benchmark,
+    filepaths: List[str],
+    wm_model: str,
+    attack_types: Optional[Iterable[str]] = None,
+    sampling_rate: Optional[int] = None,
+    verbose: bool = False,
+    **attack_kwargs,
+) -> DetectionReliabilityResult:
+    """Run the detection-reliability pass on ``filepaths``.
+
+    Args:
+        benchmark: ``Benchmark`` instance (already plugin-loaded).
+        filepaths: list of audio file paths.
+        wm_model: name of a zero-bit watermarking model.
+        attack_types: optional list of attack class names to evaluate.
+            When non-empty, FP/FN are also reported per attack and the
+            three always-on metrics (PESQ, ViSQOL, STOI) are recorded
+            for the per-attack table.
+        sampling_rate: defaults to the model config's sampling rate.
+        verbose: extra per-file logging.
+        **attack_kwargs: forwarded to attack ``apply()`` calls (CLI
+            overrides for attack-specific parameters).
+
+    Returns:
+        ``DetectionReliabilityResult`` with no-attack and per-attack
+        FP/FN counts plus accuracy / always-on metric means.
+
+    Raises:
+        ValueError: if ``wm_model`` isn't a zero-bit model.
+    """
+    if wm_model not in benchmark.models:
+        raise ValueError(
+            f"Model '{wm_model}' not found. "
+            f"Available: {list(benchmark.models.keys())}"
+        )
+
+    model_config = benchmark.models[wm_model]["config"] or {}
+    is_zero_bit = model_config.get("is_zero_bit", False)
+    if not is_zero_bit:
+        raise ValueError(
+            "--detection_reliability is currently supported only for "
+            f"zero-bit models. '{wm_model}' is not zero-bit."
+        )
+    returns_confidence = model_config.get("returns_confidence", False)
+
+    if sampling_rate is None:
+        sampling_rate = model_config["sampling_rate"]
+        logger.info(
+            f"Using default sampling rate {sampling_rate} for model {wm_model}"
+        )
+
+    model_cls = benchmark.models[wm_model]["class"]
+    model_instance = model_cls()
+
+    attack_types = list(attack_types or [])
+    n_files = len(filepaths)
+
+    # ------------------------------------------------------------------
+    # Per-file accumulators
+    # ------------------------------------------------------------------
+    fp_no_attack = 0
+    fn_no_attack = 0
+
+    # Per-attack accumulators
+    attack_state: Dict[str, Dict[str, Any]] = {
+        a: {
+            "accuracy": [],
+            "metrics": {m: [] for m in benchmark.ALWAYS_ON_METRICS},
+            "fp_count": 0,
+            "fn_count": 0,
+        }
+        for a in attack_types
+    }
+
+    for filepath in filepaths:
+        if verbose:
+            logger.info(f"Processing file: {filepath}")
+
+        audio, sr = load_audio(filepath, target_sr=sampling_rate)
+
+        # --- Step 1: FP without attack (detect on clean audio) ---
+        if _detect(model_instance, audio, sr, returns_confidence):
+            fp_no_attack += 1
+
+        # --- Step 2: embed + detect (FN without attack) ---
+        watermark = model_instance.generate_watermark()
+        watermarked_audio = model_instance.embed(
+            audio=audio, watermark_data=watermark, sampling_rate=sr,
+        )
+        if not _detect(model_instance, watermarked_audio, sr, returns_confidence):
+            fn_no_attack += 1
+
+        # --- Steps 3 + 4: per-attack FP and FN ---
+        for attack_name in attack_types:
+            attack_instance = benchmark.attacks[attack_name]["class"]()
+
+            kw_for_attack = {
+                **attack_kwargs,
+                "model": model_instance,
+                "watermark_data": watermark,
+                "sampling_rate": sr,
+                "models": benchmark.models,
+                "orig_audio": audio,
+            }
+
+            # Step 3: attack the clean audio, then detect.
+            try:
+                attacked_clean = _apply_attack(
+                    attack_instance, attack_name, audio, kw_for_attack,
+                )
+            except Exception as e:  # pragma: no cover -- log and skip file
+                logger.warning(
+                    f"Attack {attack_name} on clean audio failed for "
+                    f"{filepath}: {e}. Skipping this attack for this file."
+                )
+                continue
+
+            if _detect(model_instance, attacked_clean, sr, returns_confidence):
+                attack_state[attack_name]["fp_count"] += 1
+
+            # Step 4: attack the watermarked audio, then detect.
+            try:
+                attacked_wm = _apply_attack(
+                    attack_instance, attack_name, watermarked_audio, kw_for_attack,
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Attack {attack_name} on watermarked audio failed for "
+                    f"{filepath}: {e}. Skipping this attack for this file."
+                )
+                continue
+
+            wm_detected = _detect(
+                model_instance, attacked_wm, sr, returns_confidence,
+            )
+            if not wm_detected:
+                attack_state[attack_name]["fn_count"] += 1
+
+            # Per-attack accuracy mirrors what the basic report shows
+            # for every other attack: per-file 100/0 based on whether
+            # the watermark survived, averaged across files.
+            attack_state[attack_name]["accuracy"].append(
+                100.0 if wm_detected else 0.0
+            )
+
+            quality = compute_metrics(
+                audio, attacked_wm, sr,
+                metrics=set(benchmark.ALWAYS_ON_METRICS),
+            )
+            for m in benchmark.ALWAYS_ON_METRICS:
+                v = quality.get(m)
+                if v is not None:
+                    attack_state[attack_name]["metrics"][m].append(v)
+
+    # ------------------------------------------------------------------
+    # Aggregate per-attack means
+    # ------------------------------------------------------------------
+    attacks_summary: Dict[str, Dict[str, Any]] = {}
+    for attack_name, state in attack_state.items():
+        accuracies = state["accuracy"]
+        attacks_summary[attack_name] = {
+            "accuracy_mean": (
+                float(np.mean(accuracies)) if accuracies else None
+            ),
+            "always_on_metrics": {
+                m: (float(np.mean(vals)) if vals else None)
+                for m, vals in state["metrics"].items()
+            },
+            "false_positive_count": state["fp_count"],
+            "false_negative_count": state["fn_count"],
+        }
+
+    return DetectionReliabilityResult(
+        model_name=wm_model,
+        is_zero_bit=True,
+        n_files=n_files,
+        no_attack={
+            "false_positive_count": fp_no_attack,
+            "false_negative_count": fn_no_attack,
+        },
+        attacks=attacks_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Attack dispatch (mirrors the special cases in benchmark.run)
+# ---------------------------------------------------------------------------
+
+def _apply_attack(attack_instance, attack_name, audio, attack_kwargs):
+    """Apply ``attack_instance`` to ``audio`` honoring the model's quirks.
+
+    Mirrors the dispatch in ``benchmark.run`` for the attacks that
+    return tuples (``CrossModelAttack``) or need extra kwargs
+    (``ZeroBitCollusionAttack``). Anything else takes the default path.
+    """
+    if attack_name == "CrossModelAttack":
+        attacked_audio, _diff_watermark = attack_instance.apply(
+            audio, **attack_kwargs,
+        )
+    elif attack_name == "ZeroBitCollusionAttack":
+        kwargs = {**attack_kwargs, "original_audio_collusion": audio}
+        attacked_audio = attack_instance.apply(audio, **kwargs)
+    else:
+        attacked_audio = attack_instance.apply(audio, **attack_kwargs)
+
+    if isinstance(attacked_audio, np.ndarray):
+        attacked_audio = np.squeeze(attacked_audio)
+    return attacked_audio

--- a/src/utils/detection_reliability.py
+++ b/src/utils/detection_reliability.py
@@ -11,18 +11,16 @@ accuracy. The flow is:
     3. attack() on the clean audio, then detect()   -> false_positive_with_attack
     4. attack() on the watermarked audio, then detect() -> false_negative_with_attack
 
-Supports two model types:
-  - Zero-bit models (Perth): detect() returns binary 0/1.
-  - Confidence-based models (AudioSeal, AWARE): detect() returns
-    (watermark, confidence). Detection is positive when confidence
-    exceeds the model's detection_threshold (set in config.json).
+Each model that supports this mode must implement ``is_watermarked()``
+which takes the raw output of ``detect()`` and returns a boolean
+indicating whether a watermark is present.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional
 
 import numpy as np
 import soundfile as sf
@@ -69,37 +67,13 @@ class DetectionReliabilityResult(dict):
 
 
 # ---------------------------------------------------------------------------
-# Detection helpers
+# Detection helper
 # ---------------------------------------------------------------------------
 
-def _detect_is_positive_zero_bit(detect_output: Any) -> bool:
-    """Return True when a zero-bit detector says 'watermark detected'.
-
-    Perth returns 0 or 1.
-    Accept either int or numpy array; treat any non-zero value as positive.
-    """
-    if isinstance(detect_output, np.ndarray):
-        detect_output = detect_output.tolist()
-    if isinstance(detect_output, list):
-        return bool(detect_output[0]) if detect_output else False
-    return bool(detect_output)
-
-
-def _detect(model_instance, audio: np.ndarray, sampling_rate: int,
-            returns_confidence: bool, detection_threshold: Optional[float] = None) -> bool:
-    """Run detect() and reduce to a positive/negative boolean.
-
-    For confidence-based models, compares confidence against detection_threshold.
-    For zero-bit models, uses binary output directly.
-    """
-    if returns_confidence:
-        _watermark, confidence = model_instance.detect(audio, sampling_rate)
-        if detection_threshold is not None:
-            return float(confidence) >= detection_threshold
-        return _detect_is_positive_zero_bit(_watermark)
-    else:
-        detected = model_instance.detect(audio, sampling_rate)
-        return _detect_is_positive_zero_bit(detected)
+def _detect(model_instance, audio: np.ndarray, sampling_rate: int) -> bool:
+    """Run detect() and delegate the decision to the model's is_watermarked()."""
+    detect_output = model_instance.detect(audio, sampling_rate)
+    return model_instance.is_watermarked(detect_output)
 
 
 # ---------------------------------------------------------------------------
@@ -139,8 +113,7 @@ def run_detection_reliability(
         FP/FN counts plus accuracy and quality metric means.
 
     Raises:
-        ValueError: if ``wm_model`` is neither zero-bit nor confidence-based,
-            or if it returns confidence but has no detection_threshold configured.
+        ValueError: if ``wm_model`` does not implement ``is_watermarked()``.
     """
     if wm_model not in benchmark.models:
         raise ValueError(
@@ -150,18 +123,21 @@ def run_detection_reliability(
 
     model_config = benchmark.models[wm_model]["config"] or {}
     is_zero_bit = model_config.get("is_zero_bit", False)
-    returns_confidence = model_config.get("returns_confidence", False)
     detection_threshold = model_config.get("detection_threshold", None)
 
-    if not is_zero_bit and not returns_confidence:
+    model_cls = benchmark.models[wm_model]["class"]
+    model_instance = model_cls()
+
+    if not hasattr(model_instance, "is_watermarked"):
         raise ValueError(
-            "--detection_reliability requires either a zero-bit model or a "
-            f"confidence-based model. '{wm_model}' supports neither."
+            f"Model '{wm_model}' does not implement is_watermarked(). "
+            f"Cannot use --detection_reliability with this model."
         )
-    if returns_confidence and detection_threshold is None and not is_zero_bit:
+    from core.base_model import BaseModel
+    if isinstance(model_instance, BaseModel) and type(model_instance).is_watermarked is BaseModel.is_watermarked:
         raise ValueError(
-            f"Model '{wm_model}' returns confidence but has no "
-            f"'detection_threshold' in config.json. Cannot determine FP/FN."
+            f"Model '{wm_model}' does not implement is_watermarked(). "
+            f"Cannot use --detection_reliability with this model."
         )
 
     if sampling_rate is None:
@@ -169,9 +145,6 @@ def run_detection_reliability(
         logger.info(
             f"Using default sampling rate {sampling_rate} for model {wm_model}"
         )
-
-    model_cls = benchmark.models[wm_model]["class"]
-    model_instance = model_cls()
 
     attack_types = list(attack_types or [])
     n_files = len(filepaths)
@@ -216,7 +189,7 @@ def run_detection_reliability(
         audio, sr = load_audio(filepath, target_sr=sampling_rate)
 
         # --- Step 1: FP without attack (detect on clean audio) ---
-        if _detect(model_instance, audio, sr, returns_confidence, detection_threshold):
+        if _detect(model_instance, audio, sr):
             fp_no_attack += 1
 
         # --- Step 2: embed + detect (FN without attack) ---
@@ -224,7 +197,7 @@ def run_detection_reliability(
         watermarked_audio = model_instance.embed(
             audio=audio, watermark_data=watermark, sampling_rate=sr,
         )
-        if not _detect(model_instance, watermarked_audio, sr, returns_confidence, detection_threshold):
+        if not _detect(model_instance, watermarked_audio, sr):
             fn_no_attack += 1
 
         if save_audio and output_dir:
@@ -277,7 +250,7 @@ def run_detection_reliability(
                 )
 
             attack_state[attack_name]["fp_attempts"] += 1
-            if _detect(model_instance, attacked_clean, sr, returns_confidence, detection_threshold):
+            if _detect(model_instance, attacked_clean, sr):
                 attack_state[attack_name]["fp_count"] += 1
 
             # Step 4: attack the watermarked audio, then detect.
@@ -300,9 +273,7 @@ def run_detection_reliability(
                 )
 
             attack_state[attack_name]["fn_attempts"] += 1
-            wm_detected = _detect(
-                model_instance, attacked_wm, sr, returns_confidence, detection_threshold,
-            )
+            wm_detected = _detect(model_instance, attacked_wm, sr)
             if not wm_detected:
                 attack_state[attack_name]["fn_count"] += 1
 

--- a/src/utils/detection_reliability.py
+++ b/src/utils/detection_reliability.py
@@ -11,9 +11,11 @@ accuracy. The flow is:
     3. attack() on the clean audio, then detect()   -> false_positive_with_attack
     4. attack() on the watermarked audio, then detect() -> false_negative_with_attack
 
-Restricted to zero-bit models for now: those return a binary 0/1 from
-detect() so the FP/FN bookkeeping is unambiguous. Multi-bit models
-require a threshold on bit-accuracy that we don't want to bake in here.
+Supports two model types:
+  - Zero-bit models (Perth, StariVigil): detect() returns binary 0/1.
+  - Confidence-based models (AudioSeal, AWARE): detect() returns
+    (watermark, confidence). Detection is positive when confidence
+    exceeds the model's detection_threshold (set in config.json).
 """
 
 from __future__ import annotations
@@ -23,8 +25,10 @@ import os
 from typing import Any, Dict, Iterable, List, Optional
 
 import numpy as np
+import soundfile as sf
 
 from utils.metrics import ALL_METRICS, compute_metrics
+from utils.attack_groups import get_metrics_for_attack
 from utils.utils import load_audio
 
 logger = logging.getLogger(__name__)
@@ -41,18 +45,22 @@ class DetectionReliabilityResult(dict):
 
         {
             "model_name": str,
-            "is_zero_bit": True,
+            "is_zero_bit": bool,
+            "detection_threshold": float | None,
             "n_files": int,
             "no_attack": {
-                "false_positive_count": int,    # detected on clean audio
-                "false_negative_count": int,    # missed on watermarked audio
+                "false_positive_count": int,
+                "false_negative_count": int,
+                "metrics": {...} | absent,
             },
             "attacks": {
                 attack_name: {
-                    "accuracy_mean": float,
-                    "always_on_metrics": {"pesq": float, "visqol": float, "stoi": float},
+                    "accuracy_mean": float | None,
+                    "metrics": {metric_name: float | None, ...},
                     "false_positive_count": int,
+                    "false_positive_attempts": int,
                     "false_negative_count": int,
+                    "false_negative_attempts": int,
                 },
                 ...
             },
@@ -64,29 +72,34 @@ class DetectionReliabilityResult(dict):
 # Detection helpers
 # ---------------------------------------------------------------------------
 
-def _detect_is_positive(detect_output: Any) -> bool:
+def _detect_is_positive_zero_bit(detect_output: Any) -> bool:
     """Return True when a zero-bit detector says 'watermark detected'.
 
-    Perth returns 0 or 1 (with ``round=True``) and StariVigil returns the
-    same shape; both collapse to a scalar after ``.item()`` / ``tolist()``.
+    Perth returns 0 or 1; StariVigil returns the same shape.
     Accept either int or numpy array; treat any non-zero value as positive.
     """
     if isinstance(detect_output, np.ndarray):
         detect_output = detect_output.tolist()
     if isinstance(detect_output, list):
-        # Some zero-bit models may return a single-element list.
         return bool(detect_output[0]) if detect_output else False
     return bool(detect_output)
 
 
 def _detect(model_instance, audio: np.ndarray, sampling_rate: int,
-            returns_confidence: bool) -> bool:
-    """Run detect() and reduce to a positive/negative boolean."""
+            returns_confidence: bool, detection_threshold: Optional[float] = None) -> bool:
+    """Run detect() and reduce to a positive/negative boolean.
+
+    For confidence-based models, compares confidence against detection_threshold.
+    For zero-bit models, uses binary output directly.
+    """
     if returns_confidence:
-        detected, _confidence = model_instance.detect(audio, sampling_rate)
+        _watermark, confidence = model_instance.detect(audio, sampling_rate)
+        if detection_threshold is not None:
+            return float(confidence) >= detection_threshold
+        return _detect_is_positive_zero_bit(_watermark)
     else:
         detected = model_instance.detect(audio, sampling_rate)
-    return _detect_is_positive(detected)
+        return _detect_is_positive_zero_bit(detected)
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +113,9 @@ def run_detection_reliability(
     attack_types: Optional[Iterable[str]] = None,
     sampling_rate: Optional[int] = None,
     verbose: bool = False,
+    calculate_quality_metrics: bool = False,
+    save_audio: bool = False,
+    output_dir: Optional[str] = None,
     **attack_kwargs,
 ) -> DetectionReliabilityResult:
     """Run the detection-reliability pass on ``filepaths``.
@@ -107,22 +123,24 @@ def run_detection_reliability(
     Args:
         benchmark: ``Benchmark`` instance (already plugin-loaded).
         filepaths: list of audio file paths.
-        wm_model: name of a zero-bit watermarking model.
+        wm_model: name of a zero-bit or confidence-based watermarking model.
         attack_types: optional list of attack class names to evaluate.
-            When non-empty, FP/FN are also reported per attack and the
-            three always-on metrics (PESQ, ViSQOL, STOI) are recorded
-            for the per-attack table.
+            When non-empty, FP/FN are also reported per attack with
+            group-specific quality metrics (via ``get_metrics_for_attack``).
         sampling_rate: defaults to the model config's sampling rate.
         verbose: extra per-file logging.
+        calculate_quality_metrics: when True, computes ALL_METRICS for the
+            no-attack case (original vs watermarked).
         **attack_kwargs: forwarded to attack ``apply()`` calls (CLI
             overrides for attack-specific parameters).
 
     Returns:
         ``DetectionReliabilityResult`` with no-attack and per-attack
-        FP/FN counts plus accuracy / always-on metric means.
+        FP/FN counts plus accuracy and quality metric means.
 
     Raises:
-        ValueError: if ``wm_model`` isn't a zero-bit model.
+        ValueError: if ``wm_model`` is neither zero-bit nor confidence-based,
+            or if it returns confidence but has no detection_threshold configured.
     """
     if wm_model not in benchmark.models:
         raise ValueError(
@@ -132,12 +150,19 @@ def run_detection_reliability(
 
     model_config = benchmark.models[wm_model]["config"] or {}
     is_zero_bit = model_config.get("is_zero_bit", False)
-    if not is_zero_bit:
-        raise ValueError(
-            "--detection_reliability is currently supported only for "
-            f"zero-bit models. '{wm_model}' is not zero-bit."
-        )
     returns_confidence = model_config.get("returns_confidence", False)
+    detection_threshold = model_config.get("detection_threshold", None)
+
+    if not is_zero_bit and not returns_confidence:
+        raise ValueError(
+            "--detection_reliability requires either a zero-bit model or a "
+            f"confidence-based model. '{wm_model}' supports neither."
+        )
+    if returns_confidence and detection_threshold is None and not is_zero_bit:
+        raise ValueError(
+            f"Model '{wm_model}' returns confidence but has no "
+            f"'detection_threshold' in config.json. Cannot determine FP/FN."
+        )
 
     if sampling_rate is None:
         sampling_rate = model_config["sampling_rate"]
@@ -151,19 +176,35 @@ def run_detection_reliability(
     attack_types = list(attack_types or [])
     n_files = len(filepaths)
 
+    if save_audio and output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+
     # ------------------------------------------------------------------
     # Per-file accumulators
     # ------------------------------------------------------------------
     fp_no_attack = 0
     fn_no_attack = 0
+    no_attack_metrics: Dict[str, List[float]] = {
+        m: [] for m in ALL_METRICS
+    }
 
-    # Per-attack accumulators
+    # Per-attack accumulators — full group metrics when calculate_quality_metrics,
+    # otherwise just always-on (pesq, visqol, stoi).
+    ALWAYS_ON = ["pesq", "visqol", "stoi"]
+
+    def _metrics_for(attack_name):
+        if calculate_quality_metrics:
+            return get_metrics_for_attack(attack_name)
+        return ALWAYS_ON
+
     attack_state: Dict[str, Dict[str, Any]] = {
         a: {
             "accuracy": [],
-            "metrics": {m: [] for m in benchmark.ALWAYS_ON_METRICS},
+            "metrics": {m: [] for m in _metrics_for(a)},
             "fp_count": 0,
+            "fp_attempts": 0,
             "fn_count": 0,
+            "fn_attempts": 0,
         }
         for a in attack_types
     }
@@ -175,7 +216,7 @@ def run_detection_reliability(
         audio, sr = load_audio(filepath, target_sr=sampling_rate)
 
         # --- Step 1: FP without attack (detect on clean audio) ---
-        if _detect(model_instance, audio, sr, returns_confidence):
+        if _detect(model_instance, audio, sr, returns_confidence, detection_threshold):
             fp_no_attack += 1
 
         # --- Step 2: embed + detect (FN without attack) ---
@@ -183,8 +224,25 @@ def run_detection_reliability(
         watermarked_audio = model_instance.embed(
             audio=audio, watermark_data=watermark, sampling_rate=sr,
         )
-        if not _detect(model_instance, watermarked_audio, sr, returns_confidence):
+        if not _detect(model_instance, watermarked_audio, sr, returns_confidence, detection_threshold):
             fn_no_attack += 1
+
+        if save_audio and output_dir:
+            base = os.path.splitext(os.path.basename(filepath))[0]
+            sf.write(
+                os.path.join(output_dir, f"{base}_watermarked.wav"),
+                watermarked_audio, sr,
+            )
+
+        if calculate_quality_metrics:
+            quality = compute_metrics(
+                audio, watermarked_audio, sr,
+                metrics=set(ALL_METRICS),
+            )
+            for m in ALL_METRICS:
+                v = quality.get(m)
+                if v is not None:
+                    no_attack_metrics[m].append(v)
 
         # --- Steps 3 + 4: per-attack FP and FN ---
         for attack_name in attack_types:
@@ -211,7 +269,8 @@ def run_detection_reliability(
                 )
                 continue
 
-            if _detect(model_instance, attacked_clean, sr, returns_confidence):
+            attack_state[attack_name]["fp_attempts"] += 1
+            if _detect(model_instance, attacked_clean, sr, returns_confidence, detection_threshold):
                 attack_state[attack_name]["fp_count"] += 1
 
             # Step 4: attack the watermarked audio, then detect.
@@ -226,8 +285,16 @@ def run_detection_reliability(
                 )
                 continue
 
+            if save_audio and output_dir:
+                base = os.path.splitext(os.path.basename(filepath))[0]
+                sf.write(
+                    os.path.join(output_dir, f"{base}_{attack_name}.wav"),
+                    attacked_wm, sr,
+                )
+
+            attack_state[attack_name]["fn_attempts"] += 1
             wm_detected = _detect(
-                model_instance, attacked_wm, sr, returns_confidence,
+                model_instance, attacked_wm, sr, returns_confidence, detection_threshold,
             )
             if not wm_detected:
                 attack_state[attack_name]["fn_count"] += 1
@@ -239,11 +306,12 @@ def run_detection_reliability(
                 100.0 if wm_detected else 0.0
             )
 
+            attack_metrics = _metrics_for(attack_name)
             quality = compute_metrics(
                 audio, attacked_wm, sr,
-                metrics=set(benchmark.ALWAYS_ON_METRICS),
+                metrics=set(attack_metrics),
             )
-            for m in benchmark.ALWAYS_ON_METRICS:
+            for m in attack_metrics:
                 v = quality.get(m)
                 if v is not None:
                     attack_state[attack_name]["metrics"][m].append(v)
@@ -258,22 +326,32 @@ def run_detection_reliability(
             "accuracy_mean": (
                 float(np.mean(accuracies)) if accuracies else None
             ),
-            "always_on_metrics": {
+            "metrics": {
                 m: (float(np.mean(vals)) if vals else None)
                 for m, vals in state["metrics"].items()
             },
             "false_positive_count": state["fp_count"],
+            "false_positive_attempts": state["fp_attempts"],
             "false_negative_count": state["fn_count"],
+            "false_negative_attempts": state["fn_attempts"],
+        }
+
+    no_attack_result = {
+        "false_positive_count": fp_no_attack,
+        "false_negative_count": fn_no_attack,
+    }
+    if calculate_quality_metrics:
+        no_attack_result["metrics"] = {
+            m: (float(np.mean(vals)) if vals else None)
+            for m, vals in no_attack_metrics.items()
         }
 
     return DetectionReliabilityResult(
         model_name=wm_model,
-        is_zero_bit=True,
+        is_zero_bit=is_zero_bit,
+        detection_threshold=detection_threshold,
         n_files=n_files,
-        no_attack={
-            "false_positive_count": fp_no_attack,
-            "false_negative_count": fn_no_attack,
-        },
+        no_attack=no_attack_result,
         attacks=attacks_summary,
     )
 

--- a/src/utils/detection_reliability_report_generator.py
+++ b/src/utils/detection_reliability_report_generator.py
@@ -1,0 +1,228 @@
+"""LaTeX report for the --detection_reliability mode.
+
+The report is its own .tex/.pdf so the existing benchmark/no-attacks
+reports stay untouched. Layout:
+
+  Section 1 — No-Attack Reliability
+    One-row-per-metric table: false positives on clean audio, false
+    negatives on watermarked audio. Shows count and percentage.
+
+  Section 2 — Per-Attack Accuracy & Quality (only if attacks were run)
+    One row per attack: accuracy + the three always-on quality metrics
+    (PESQ, ViSQOL, STOI), matching the basic benchmark report.
+
+  Section 3 — Per-Attack Reliability (only if attacks were run)
+    One row per attack: FP and FN with the attack applied to clean and
+    watermarked audio respectively. Counts and percentages.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from utils.latex_helpers import (
+    build_longtable,
+    compile_latex,
+    display_attack_name,
+    make_preamble,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _format_count(count: int, total: int) -> str:
+    """Render an FP/FN count as ``count/total`` for the Count column."""
+    if total <= 0:
+        return "N/A"
+    return f"{count}/{total}"
+
+
+def _format_pct(count: int, total: int) -> str:
+    """Render an FP/FN ratio as ``pct%`` for the Rate column."""
+    if total <= 0:
+        return "N/A"
+    pct = 100.0 * count / total
+    return f"{pct:.1f}\\%"
+
+
+def _format_metric(value):
+    return "N/A" if value is None else f"{float(value):.2f}"
+
+
+def _short_model_name(name: str) -> str:
+    for suffix in ("Model", "Watermark"):
+        if name.endswith(suffix) and len(name) > len(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def _no_attack_table(result: Dict[str, Any]) -> str:
+    """Two-row table: false positives + false negatives without attack."""
+    n = int(result["n_files"])
+    fp = int(result["no_attack"]["false_positive_count"])
+    fn = int(result["no_attack"]["false_negative_count"])
+
+    rows = [
+        f"    False Positive & {_format_count(fp, n)} & {_format_pct(fp, n)} \\\\",
+        f"    False Negative & {_format_count(fn, n)} & {_format_pct(fn, n)} \\\\",
+    ]
+    header = "Metric & Count & Rate"
+    caption = (
+        "Detection reliability without attacks. "
+        "False positive: detection on the clean original. "
+        "False negative: missed detection on the watermarked signal."
+    )
+    return build_longtable(
+        col_spec="lcc",
+        header=header,
+        rows=rows,
+        caption=caption,
+        label="tab:detection_reliability_no_attack",
+    )
+
+
+def _per_attack_quality_table(result: Dict[str, Any]) -> str:
+    """One row per attack: accuracy + always-on quality metrics."""
+    attacks = result.get("attacks") or {}
+    if not attacks:
+        return ""
+
+    rows = []
+    for attack_name in sorted(attacks.keys()):
+        data = attacks[attack_name]
+        display = display_attack_name(attack_name)
+        acc = (
+            "N/A"
+            if data.get("accuracy_mean") is None
+            else f"{data['accuracy_mean']:.2f}\\%"
+        )
+        q = data.get("always_on_metrics") or {}
+        rows.append(
+            f"    {display} & {acc} & {_format_metric(q.get('pesq'))} "
+            f"& {_format_metric(q.get('visqol'))} "
+            f"& {_format_metric(q.get('stoi'))} \\\\"
+        )
+
+    header = "Attack & Accuracy & PESQ & ViSQOL & STOI"
+    caption = (
+        "Watermark detection accuracy and always-on audio quality "
+        "metrics per attack. Accuracy is the share of files where the "
+        "watermark survived the attack."
+    )
+    return build_longtable(
+        col_spec="lcccc",
+        header=header,
+        rows=rows,
+        caption=caption,
+        label="tab:detection_reliability_per_attack_quality",
+    )
+
+
+def _per_attack_reliability_table(result: Dict[str, Any]) -> str:
+    """One row per attack: FP and FN counts with attack applied."""
+    attacks = result.get("attacks") or {}
+    if not attacks:
+        return ""
+
+    n = int(result["n_files"])
+    rows = []
+    for attack_name in sorted(attacks.keys()):
+        data = attacks[attack_name]
+        display = display_attack_name(attack_name)
+        fp = int(data.get("false_positive_count", 0))
+        fn = int(data.get("false_negative_count", 0))
+        rows.append(
+            f"    {display} & {_format_count(fp, n)} & {_format_pct(fp, n)} "
+            f"& {_format_count(fn, n)} & {_format_pct(fn, n)} \\\\"
+        )
+
+    header = "Attack & FP Count & FP Rate & FN Count & FN Rate"
+    caption = (
+        "Detection reliability with attacks. False positive: detection "
+        "after applying the attack to the clean original. False "
+        "negative: missed detection after applying the attack to the "
+        "watermarked signal."
+    )
+    return build_longtable(
+        col_spec="lcccc",
+        header=header,
+        rows=rows,
+        caption=caption,
+        label="tab:detection_reliability_per_attack",
+    )
+
+
+def generate_detection_reliability_report(
+    result: Dict[str, Any], report_dir: str = "report",
+) -> str:
+    """Write the detection-reliability LaTeX report and compile to PDF."""
+    os.makedirs(report_dir, exist_ok=True)
+    has_cls = os.path.exists(os.path.join(report_dir, "deepmark.cls"))
+
+    model_name = result.get("model_name", "DeepMark")
+    short_name = _short_model_name(model_name)
+    n_files = int(result.get("n_files", 0))
+
+    preamble = make_preamble(
+        title=f"Detection Reliability Report: {short_name}",
+        author="DeepMark Benchmark System",
+        has_deepmark_cls=has_cls,
+    )
+
+    has_attacks = bool(result.get("attacks"))
+
+    abstract = (
+        f"\\begin{{abstract}}\n"
+        f"This report measures detection reliability for the "
+        f"{short_name} watermarking model across {n_files} "
+        f"{'file' if n_files == 1 else 'files'}. False positives are "
+        f"detections on the clean (non-watermarked) input; false "
+        f"negatives are missed detections on the watermarked input. "
+    )
+    if has_attacks:
+        abstract += (
+            "When attacks are configured, the same two metrics are also "
+            "reported with each attack applied -- to the clean original "
+            "for the false-positive measurement, and to the watermarked "
+            "signal for the false-negative measurement.\n"
+        )
+    else:
+        abstract += "\n"
+    abstract += "\\end{abstract}\n\n"
+
+    sections = [
+        "\\section{No-Attack Reliability}\n\n"
+        + _no_attack_table(result)
+    ]
+
+    if has_attacks:
+        per_attack_quality = _per_attack_quality_table(result)
+        if per_attack_quality:
+            sections.append(
+                "\\section{Per-Attack Accuracy and Audio Quality}\n\n"
+                + per_attack_quality
+            )
+
+        per_attack_reliability = _per_attack_reliability_table(result)
+        if per_attack_reliability:
+            sections.append(
+                "\\section{Per-Attack Reliability}\n\n"
+                + per_attack_reliability
+            )
+
+    latex_content = (
+        f"{preamble}\n\n"
+        + abstract
+        + "\n\n".join(sections)
+        + "\n\n\\end{document}"
+    )
+
+    tex_path = os.path.join(report_dir, "detection_reliability_report.tex")
+    with open(tex_path, "w") as f:
+        f.write(latex_content)
+    logger.info(f"Detection reliability LaTeX report saved to {tex_path}")
+
+    compile_latex(report_dir, "detection_reliability_report")
+    return tex_path

--- a/src/utils/detection_reliability_report_generator.py
+++ b/src/utils/detection_reliability_report_generator.py
@@ -1,46 +1,59 @@
 """LaTeX report for the --detection_reliability mode.
 
-The report is its own .tex/.pdf so the existing benchmark/no-attacks
-reports stay untouched. Layout:
+Layout depends on whether attacks are provided:
 
-  Section 1 — No-Attack Reliability
-    One-row-per-metric table: false positives on clean audio, false
-    negatives on watermarked audio. Shows count and percentage.
+  Without attacks:
+    Section 1 — No-Attack Reliability (FP/FN table)
+    Section 2 — Watermarked Audio Quality (if --calculate_quality_metrics)
 
-  Section 2 — Per-Attack Accuracy & Quality (only if attacks were run)
-    One row per attack: accuracy + the three always-on quality metrics
-    (PESQ, ViSQOL, STOI), matching the basic benchmark report.
-
-  Section 3 — Per-Attack Reliability (only if attacks were run)
-    One row per attack: FP and FN with the attack applied to clean and
-    watermarked audio respectively. Counts and percentages.
+  With attacks (no --no_attacks):
+    Per-group sections, each containing:
+      - Accuracy + FP/FN table
+      - Always-on metrics table (PESQ, ViSQOL, STOI) by default
+      - OR three separate tables (quality, intelligibility, NISQA)
+        when --calculate_quality_metrics is set
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
+from utils.attack_groups import (
+    ATTACK_GROUPS,
+    group_attacks,
+    get_group_for_attack,
+)
 from utils.latex_helpers import (
     build_longtable,
     compile_latex,
     display_attack_name,
     make_preamble,
 )
+from utils.metrics import METRIC_LABELS, NISQA_METRICS
 
 logger = logging.getLogger(__name__)
 
+ALWAYS_ON_METRICS = ["pesq", "visqol", "stoi"]
+
+GROUP_ORDER = [
+    "process_disruption",
+    "audio_editing",
+    "audio_distortion",
+    "desynchronization",
+    "ai_attacks",
+    "transmission",
+]
+
 
 def _format_count(count: int, total: int) -> str:
-    """Render an FP/FN count as ``count/total`` for the Count column."""
     if total <= 0:
         return "N/A"
     return f"{count}/{total}"
 
 
 def _format_pct(count: int, total: int) -> str:
-    """Render an FP/FN ratio as ``pct%`` for the Rate column."""
     if total <= 0:
         return "N/A"
     pct = 100.0 * count / total
@@ -48,18 +61,28 @@ def _format_pct(count: int, total: int) -> str:
 
 
 def _format_metric(value):
-    return "N/A" if value is None else f"{float(value):.2f}"
+    if value is None or value == "N/A":
+        return "N/A"
+    return f"{float(value):.2f}"
 
 
 def _short_model_name(name: str) -> str:
     for suffix in ("Model", "Watermark"):
         if name.endswith(suffix) and len(name) > len(suffix):
-            return name[: -len(suffix)]
-    return name
+            name = name[: -len(suffix)]
+            break
+    return name.replace("_", "\\_").replace("&", "\\&").replace("#", "\\#")
 
 
-def _no_attack_table(result: Dict[str, Any]) -> str:
-    """Two-row table: false positives + false negatives without attack."""
+def _metric_label(metric_name: str) -> str:
+    return METRIC_LABELS.get(metric_name, metric_name.upper().replace("_", " "))
+
+
+# ---------------------------------------------------------------------------
+# No-attack tables
+# ---------------------------------------------------------------------------
+
+def _no_attack_reliability_table(result: Dict[str, Any]) -> str:
     n = int(result["n_files"])
     fp = int(result["no_attack"]["false_positive_count"])
     fn = int(result["no_attack"]["false_negative_count"])
@@ -68,91 +91,204 @@ def _no_attack_table(result: Dict[str, Any]) -> str:
         f"    False Positive & {_format_count(fp, n)} & {_format_pct(fp, n)} \\\\",
         f"    False Negative & {_format_count(fn, n)} & {_format_pct(fn, n)} \\\\",
     ]
-    header = "Metric & Count & Rate"
-    caption = (
-        "Detection reliability without attacks. "
-        "False positive: detection on the clean original. "
-        "False negative: missed detection on the watermarked signal."
-    )
     return build_longtable(
         col_spec="lcc",
-        header=header,
+        header="Metric & Count & Rate",
         rows=rows,
-        caption=caption,
-        label="tab:detection_reliability_no_attack",
+        caption=(
+            "Detection reliability without attacks. "
+            "False positive: detection on the clean original. "
+            "False negative: missed detection on the watermarked signal."
+        ),
+        label="tab:dr_no_attack",
     )
 
 
-def _per_attack_quality_table(result: Dict[str, Any]) -> str:
-    """One row per attack: accuracy + always-on quality metrics."""
-    attacks = result.get("attacks") or {}
-    if not attacks:
+def _no_attack_quality_table(result: Dict[str, Any]) -> str:
+    metrics = result.get("no_attack", {}).get("metrics")
+    if not metrics:
         return ""
 
     rows = []
-    for attack_name in sorted(attacks.keys()):
-        data = attacks[attack_name]
-        display = display_attack_name(attack_name)
+    for metric_name, value in metrics.items():
+        rows.append(f"    {_metric_label(metric_name)} & {_format_metric(value)} \\\\")
+
+    return build_longtable(
+        col_spec="lc",
+        header="Metric & Value",
+        rows=rows,
+        caption=(
+            "Audio quality metrics for watermarked audio compared to the "
+            "original (no attack applied)."
+        ),
+        label="tab:dr_no_attack_quality",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-attack tables (with attacks)
+# ---------------------------------------------------------------------------
+
+def _accuracy_fp_fn_table(attacks: Dict[str, Any], attack_names: List[str],
+                          n_files: int, caption: str, label: str) -> str:
+    """Accuracy + FP/FN for a list of attacks."""
+    rows = []
+    for name in attack_names:
+        if name not in attacks:
+            continue
+        data = attacks[name]
+        display = display_attack_name(name)
         acc = (
             "N/A"
             if data.get("accuracy_mean") is None
             else f"{data['accuracy_mean']:.2f}\\%"
         )
-        q = data.get("always_on_metrics") or {}
+        fp = int(data.get("false_positive_count", 0))
+        fp_n = int(data.get("false_positive_attempts", n_files))
+        fn = int(data.get("false_negative_count", 0))
+        fn_n = int(data.get("false_negative_attempts", n_files))
         rows.append(
-            f"    {display} & {acc} & {_format_metric(q.get('pesq'))} "
-            f"& {_format_metric(q.get('visqol'))} "
-            f"& {_format_metric(q.get('stoi'))} \\\\"
+            f"    {display} & {acc} & {_format_count(fp, fp_n)} & {_format_pct(fp, fp_n)} "
+            f"& {_format_count(fn, fn_n)} & {_format_pct(fn, fn_n)} \\\\"
         )
 
-    header = "Attack & Accuracy & PESQ & ViSQOL & STOI"
-    caption = (
-        "Watermark detection accuracy and always-on audio quality "
-        "metrics per attack. Accuracy is the share of files where the "
-        "watermark survived the attack."
-    )
-    return build_longtable(
-        col_spec="lcccc",
-        header=header,
-        rows=rows,
-        caption=caption,
-        label="tab:detection_reliability_per_attack_quality",
-    )
-
-
-def _per_attack_reliability_table(result: Dict[str, Any]) -> str:
-    """One row per attack: FP and FN counts with attack applied."""
-    attacks = result.get("attacks") or {}
-    if not attacks:
+    if not rows:
         return ""
 
-    n = int(result["n_files"])
-    rows = []
-    for attack_name in sorted(attacks.keys()):
-        data = attacks[attack_name]
-        display = display_attack_name(attack_name)
-        fp = int(data.get("false_positive_count", 0))
-        fn = int(data.get("false_negative_count", 0))
-        rows.append(
-            f"    {display} & {_format_count(fp, n)} & {_format_pct(fp, n)} "
-            f"& {_format_count(fn, n)} & {_format_pct(fn, n)} \\\\"
-        )
-
-    header = "Attack & FP Count & FP Rate & FN Count & FN Rate"
-    caption = (
-        "Detection reliability with attacks. False positive: detection "
-        "after applying the attack to the clean original. False "
-        "negative: missed detection after applying the attack to the "
-        "watermarked signal."
-    )
     return build_longtable(
-        col_spec="lcccc",
-        header=header,
+        col_spec="lccccc",
+        header="Attack & Accuracy & FP Count & FP Rate & FN Count & FN Rate",
         rows=rows,
         caption=caption,
-        label="tab:detection_reliability_per_attack",
+        label=label,
     )
 
+
+def _always_on_table(attacks: Dict[str, Any], attack_names: List[str],
+                     caption: str, label: str) -> str:
+    """PESQ, ViSQOL, STOI table for a list of attacks."""
+    rows = []
+    for name in attack_names:
+        if name not in attacks:
+            continue
+        data = attacks[name]
+        display = display_attack_name(name)
+        q = data.get("metrics") or {}
+        cols = " & ".join(_format_metric(q.get(m)) for m in ALWAYS_ON_METRICS)
+        rows.append(f"    {display} & {cols} \\\\")
+
+    if not rows:
+        return ""
+
+    headers = " & ".join(_metric_label(m) for m in ALWAYS_ON_METRICS)
+    return build_longtable(
+        col_spec="l" + "c" * len(ALWAYS_ON_METRICS),
+        header=f"Attack & {headers}",
+        rows=rows,
+        caption=caption,
+        label=label,
+    )
+
+
+def _metrics_table(attacks: Dict[str, Any], attack_names: List[str],
+                   metric_keys: List[str], caption: str, label: str) -> str:
+    """Generic metrics table for a list of attacks and metric keys."""
+    if not metric_keys:
+        return ""
+
+    rows = []
+    for name in attack_names:
+        if name not in attacks:
+            continue
+        data = attacks[name]
+        display = display_attack_name(name)
+        q = data.get("metrics") or {}
+        cols = " & ".join(_format_metric(q.get(m)) for m in metric_keys)
+        rows.append(f"    {display} & {cols} \\\\")
+
+    if not rows:
+        return ""
+
+    headers = " & ".join(_metric_label(m) for m in metric_keys)
+    return build_longtable(
+        col_spec="l" + "c" * len(metric_keys),
+        header=f"Attack & {headers}",
+        rows=rows,
+        caption=caption,
+        label=label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group section builder
+# ---------------------------------------------------------------------------
+
+def _build_group_section(attacks: Dict[str, Any], attack_names: List[str],
+                         group_key: str, group_label: str, n_files: int,
+                         calculate_quality_metrics: bool) -> str:
+    """Build a full section for one attack group."""
+    present = [a for a in attack_names if a in attacks]
+    if not present:
+        return ""
+
+    section = f"\\section{{{group_label}}}\n\n"
+
+    # Accuracy + FP/FN table (always present)
+    section += _accuracy_fp_fn_table(
+        attacks, present, n_files,
+        caption=f"Detection accuracy and reliability --- {group_label}.",
+        label=f"tab:dr_acc_{group_key}",
+    )
+    section += "\n\n"
+
+    if calculate_quality_metrics:
+        group_def = ATTACK_GROUPS.get(group_key, {})
+        q_metrics = group_def.get("quality_metrics", [])
+        i_metrics = group_def.get("intelligibility_metrics", [])
+        n_metrics = group_def.get("nisqa_metrics", [])
+
+        # Quality metrics (without NISQA)
+        q_no_nisqa = [m for m in q_metrics if m not in NISQA_METRICS]
+        if q_no_nisqa:
+            section += _metrics_table(
+                attacks, present, q_no_nisqa,
+                caption=f"Audio quality --- {group_label}.",
+                label=f"tab:dr_qual_{group_key}",
+            )
+            section += "\n\n"
+
+        # Intelligibility metrics
+        if i_metrics:
+            section += _metrics_table(
+                attacks, present, i_metrics,
+                caption=f"Speech intelligibility --- {group_label}.",
+                label=f"tab:dr_intell_{group_key}",
+            )
+            section += "\n\n"
+
+        # NISQA metrics
+        if n_metrics:
+            section += _metrics_table(
+                attacks, present, n_metrics,
+                caption=f"NISQA non-intrusive quality --- {group_label}.",
+                label=f"tab:dr_nisqa_{group_key}",
+            )
+            section += "\n\n"
+    else:
+        # Always-on metrics only
+        section += _always_on_table(
+            attacks, present,
+            caption=f"Audio quality (always-on) --- {group_label}.",
+            label=f"tab:dr_ao_{group_key}",
+        )
+        section += "\n\n"
+
+    return section
+
+
+# ---------------------------------------------------------------------------
+# Main generator
+# ---------------------------------------------------------------------------
 
 def generate_detection_reliability_report(
     result: Dict[str, Any], report_dir: str = "report",
@@ -164,6 +300,14 @@ def generate_detection_reliability_report(
     model_name = result.get("model_name", "DeepMark")
     short_name = _short_model_name(model_name)
     n_files = int(result.get("n_files", 0))
+    has_attacks = bool(result.get("attacks"))
+    has_quality_metrics = bool(
+        result.get("no_attack", {}).get("metrics")
+        or any(
+            len(d.get("metrics", {})) > 3
+            for d in (result.get("attacks") or {}).values()
+        )
+    )
 
     preamble = make_preamble(
         title=f"Detection Reliability Report: {short_name}",
@@ -171,46 +315,70 @@ def generate_detection_reliability_report(
         has_deepmark_cls=has_cls,
     )
 
-    has_attacks = bool(result.get("attacks"))
-
     abstract = (
         f"\\begin{{abstract}}\n"
         f"This report measures detection reliability for the "
         f"{short_name} watermarking model across {n_files} "
-        f"{'file' if n_files == 1 else 'files'}. False positives are "
-        f"detections on the clean (non-watermarked) input; false "
-        f"negatives are missed detections on the watermarked input. "
+        f"{'file' if n_files == 1 else 'files'}. "
+    )
+    threshold = result.get("detection_threshold")
+    if threshold is not None:
+        abstract += (
+            f"Detection threshold: {threshold} (confidence-based model). "
+        )
+    abstract += (
+        "False positives are detections on the clean (non-watermarked) input; "
+        "false negatives are missed detections on the watermarked input."
     )
     if has_attacks:
         abstract += (
-            "When attacks are configured, the same two metrics are also "
-            "reported with each attack applied -- to the clean original "
-            "for the false-positive measurement, and to the watermarked "
-            "signal for the false-negative measurement.\n"
+            " Per-attack results are grouped by attack category with "
+            "FP/FN rates and quality metrics."
         )
+    abstract += "\n\\end{abstract}\n\n"
+
+    sections = []
+
+    if not has_attacks:
+        # No attacks: show FP/FN + quality metrics
+        sections.append(
+            "\\section{No-Attack Reliability}\n\n"
+            + _no_attack_reliability_table(result)
+        )
+        quality = _no_attack_quality_table(result)
+        if quality:
+            sections.append(
+                "\\section{Watermarked Audio Quality}\n\n" + quality
+            )
     else:
-        abstract += "\n"
-    abstract += "\\end{abstract}\n\n"
+        # With attacks: grouped sections
+        attacks = result.get("attacks", {})
+        attack_names = list(attacks.keys())
+        grouped = group_attacks(attack_names)
 
-    sections = [
-        "\\section{No-Attack Reliability}\n\n"
-        + _no_attack_table(result)
-    ]
-
-    if has_attacks:
-        per_attack_quality = _per_attack_quality_table(result)
-        if per_attack_quality:
-            sections.append(
-                "\\section{Per-Attack Accuracy and Audio Quality}\n\n"
-                + per_attack_quality
+        for group_key in GROUP_ORDER:
+            if group_key not in grouped:
+                continue
+            group_info = grouped[group_key]
+            group_label = ATTACK_GROUPS.get(group_key, {}).get(
+                "label", group_info["label"]
             )
-
-        per_attack_reliability = _per_attack_reliability_table(result)
-        if per_attack_reliability:
-            sections.append(
-                "\\section{Per-Attack Reliability}\n\n"
-                + per_attack_reliability
+            section = _build_group_section(
+                attacks, group_info["attacks"], group_key, group_label,
+                n_files, has_quality_metrics,
             )
+            if section:
+                sections.append(section)
+
+        # Handle attacks not in any known group
+        if "other" in grouped:
+            other_attacks = grouped["other"]["attacks"]
+            section = _build_group_section(
+                attacks, other_attacks, "other", "Other Attacks",
+                n_files, has_quality_metrics,
+            )
+            if section:
+                sections.append(section)
 
     latex_content = (
         f"{preamble}\n\n"

--- a/tests/test_detection_reliability.py
+++ b/tests/test_detection_reliability.py
@@ -1,0 +1,315 @@
+"""Tests for the detection_reliability module."""
+
+import numpy as np
+import pytest
+
+from utils.detection_reliability import (
+    _detect,
+    _detect_is_positive_zero_bit,
+    run_detection_reliability,
+)
+from utils.detection_reliability_report_generator import (
+    _format_count,
+    _format_metric,
+    _format_pct,
+    _short_model_name,
+    _metric_label,
+    generate_detection_reliability_report,
+)
+
+
+class TestDetectIsPositiveZeroBit:
+    def test_scalar_true(self):
+        assert _detect_is_positive_zero_bit(1) is True
+
+    def test_scalar_false(self):
+        assert _detect_is_positive_zero_bit(0) is False
+
+    def test_numpy_array_positive(self):
+        assert _detect_is_positive_zero_bit(np.array(1)) is True
+
+    def test_numpy_array_zero(self):
+        assert _detect_is_positive_zero_bit(np.array(0)) is False
+
+    def test_list_positive(self):
+        assert _detect_is_positive_zero_bit([1]) is True
+
+    def test_list_zero(self):
+        assert _detect_is_positive_zero_bit([0]) is False
+
+    def test_empty_list(self):
+        assert _detect_is_positive_zero_bit([]) is False
+
+    def test_numpy_array_1d(self):
+        assert _detect_is_positive_zero_bit(np.array([1, 0, 1])) is True
+
+    def test_numpy_array_all_zeros(self):
+        assert _detect_is_positive_zero_bit(np.array([0, 0, 0])) is False
+
+
+class TestDetect:
+    """Tests for _detect with mocked models."""
+
+    class _ZeroBitModel:
+        def __init__(self, returns):
+            self._returns = returns
+
+        def detect(self, audio, sr):
+            return self._returns
+
+    class _ConfidenceModel:
+        def __init__(self, watermark, confidence):
+            self._watermark = watermark
+            self._confidence = confidence
+
+        def detect(self, audio, sr):
+            return self._watermark, self._confidence
+
+    def test_zero_bit_positive(self):
+        model = self._ZeroBitModel(np.array(1))
+        assert _detect(model, np.zeros(100), 16000, False) is True
+
+    def test_zero_bit_negative(self):
+        model = self._ZeroBitModel(np.array(0))
+        assert _detect(model, np.zeros(100), 16000, False) is False
+
+    def test_confidence_above_threshold(self):
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.8)
+        assert _detect(model, np.zeros(100), 16000, True, 0.5) is True
+
+    def test_confidence_below_threshold(self):
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.3)
+        assert _detect(model, np.zeros(100), 16000, True, 0.5) is False
+
+    def test_confidence_at_threshold(self):
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.5)
+        assert _detect(model, np.zeros(100), 16000, True, 0.5) is True
+
+    def test_confidence_no_threshold_falls_back_to_zero_bit(self):
+        model = self._ConfidenceModel(np.array([0]), 0.9)
+        assert _detect(model, np.zeros(100), 16000, True, None) is False
+
+
+class TestFormatHelpers:
+    def test_format_count_normal(self):
+        assert _format_count(3, 10) == "3/10"
+
+    def test_format_count_zero_total(self):
+        assert _format_count(0, 0) == "N/A"
+
+    def test_format_pct_normal(self):
+        assert _format_pct(1, 4) == "25.0\\%"
+
+    def test_format_pct_zero_total(self):
+        assert _format_pct(0, 0) == "N/A"
+
+    def test_format_metric_none(self):
+        assert _format_metric(None) == "N/A"
+
+    def test_format_metric_na_string(self):
+        assert _format_metric("N/A") == "N/A"
+
+    def test_format_metric_float(self):
+        assert _format_metric(3.14159) == "3.14"
+
+    def test_short_model_name_strips_model(self):
+        assert _short_model_name("AudioSealModel") == "AudioSeal"
+
+    def test_short_model_name_strips_watermark(self):
+        assert _short_model_name("TestWatermark") == "Test"
+
+    def test_short_model_name_no_suffix(self):
+        assert _short_model_name("Perth") == "Perth"
+
+    def test_short_model_name_escapes_underscore(self):
+        assert _short_model_name("My_Model") == "My\\_"
+
+    def test_metric_label_known(self):
+        assert _metric_label("pesq") == "PESQ (1--4.66)"
+
+    def test_metric_label_unknown(self):
+        assert _metric_label("some_metric") == "SOME METRIC"
+
+
+class TestRunDetectionReliability:
+    """Integration tests with a mocked benchmark."""
+
+    class _MockModel:
+        def __init__(self, is_zero_bit=True):
+            self._is_zero_bit = is_zero_bit
+
+        def generate_watermark(self):
+            return np.array([1, 0, 1, 0])
+
+        def embed(self, audio, watermark_data, sampling_rate):
+            return audio + 0.001
+
+        def detect(self, audio, sampling_rate):
+            if self._is_zero_bit:
+                return np.array(1)
+            return np.array([1, 0, 1, 0]), 0.8
+
+    class _MockBenchmark:
+        ALWAYS_ON_METRICS = ("pesq", "visqol", "stoi")
+
+        def __init__(self, is_zero_bit=True, returns_confidence=False,
+                     detection_threshold=None):
+            self.models = {
+                "TestModel": {
+                    "class": lambda: TestRunDetectionReliability._MockModel(is_zero_bit),
+                    "config": {
+                        "is_zero_bit": is_zero_bit,
+                        "returns_confidence": returns_confidence,
+                        "detection_threshold": detection_threshold,
+                        "sampling_rate": 16000,
+                    },
+                }
+            }
+            self.attacks = {}
+
+    def test_zero_bit_no_attacks(self, tmp_path):
+        audio_file = tmp_path / "test.wav"
+        import soundfile as sf
+        sr = 16000
+        audio = np.sin(np.linspace(0, 1, sr)).astype(np.float32)
+        sf.write(str(audio_file), audio, sr)
+
+        benchmark = self._MockBenchmark(is_zero_bit=True)
+        result = run_detection_reliability(
+            benchmark, [str(audio_file)], "TestModel",
+        )
+
+        assert result["model_name"] == "TestModel"
+        assert result["is_zero_bit"] is True
+        assert result["n_files"] == 1
+        assert result["no_attack"]["false_positive_count"] == 1
+        assert result["no_attack"]["false_negative_count"] == 0
+
+    def test_confidence_model_no_attacks(self, tmp_path):
+        audio_file = tmp_path / "test.wav"
+        import soundfile as sf
+        sr = 16000
+        audio = np.sin(np.linspace(0, 1, sr)).astype(np.float32)
+        sf.write(str(audio_file), audio, sr)
+
+        benchmark = self._MockBenchmark(
+            is_zero_bit=False, returns_confidence=True,
+            detection_threshold=0.5,
+        )
+        result = run_detection_reliability(
+            benchmark, [str(audio_file)], "TestModel",
+        )
+
+        assert result["is_zero_bit"] is False
+        assert result["detection_threshold"] == 0.5
+        assert result["no_attack"]["false_positive_count"] == 1
+        assert result["no_attack"]["false_negative_count"] == 0
+
+    def test_rejects_unsupported_model(self, tmp_path):
+        audio_file = tmp_path / "test.wav"
+        import soundfile as sf
+        sf.write(str(audio_file), np.zeros(16000), 16000)
+
+        benchmark = self._MockBenchmark(
+            is_zero_bit=False, returns_confidence=False,
+        )
+        with pytest.raises(ValueError, match="requires either"):
+            run_detection_reliability(
+                benchmark, [str(audio_file)], "TestModel",
+            )
+
+    def test_rejects_confidence_without_threshold(self, tmp_path):
+        audio_file = tmp_path / "test.wav"
+        import soundfile as sf
+        sf.write(str(audio_file), np.zeros(16000), 16000)
+
+        benchmark = self._MockBenchmark(
+            is_zero_bit=False, returns_confidence=True,
+            detection_threshold=None,
+        )
+        with pytest.raises(ValueError, match="detection_threshold"):
+            run_detection_reliability(
+                benchmark, [str(audio_file)], "TestModel",
+            )
+
+    def test_model_not_found(self):
+        benchmark = self._MockBenchmark()
+        with pytest.raises(ValueError, match="not found"):
+            run_detection_reliability(
+                benchmark, ["fake.wav"], "NonExistentModel",
+            )
+
+
+class TestReportGeneration:
+    def test_generates_tex_file(self, tmp_path):
+        result = {
+            "model_name": "PerthModel",
+            "is_zero_bit": True,
+            "detection_threshold": None,
+            "n_files": 5,
+            "no_attack": {
+                "false_positive_count": 1,
+                "false_negative_count": 0,
+            },
+            "attacks": {},
+        }
+        tex_path = generate_detection_reliability_report(
+            result, report_dir=str(tmp_path),
+        )
+        assert tex_path.endswith(".tex")
+        with open(tex_path) as f:
+            content = f.read()
+        assert "Perth" in content
+        assert "False Positive" in content
+
+    def test_generates_with_attacks(self, tmp_path):
+        result = {
+            "model_name": "AudioSealModel",
+            "is_zero_bit": False,
+            "detection_threshold": 0.5,
+            "n_files": 10,
+            "no_attack": {
+                "false_positive_count": 2,
+                "false_negative_count": 1,
+            },
+            "attacks": {
+                "GaussianNoiseAttack": {
+                    "accuracy_mean": 85.0,
+                    "metrics": {"pesq": 3.2, "visqol": 4.0, "stoi": 0.91},
+                    "false_positive_count": 3,
+                    "false_positive_attempts": 10,
+                    "false_negative_count": 4,
+                    "false_negative_attempts": 10,
+                },
+            },
+        }
+        tex_path = generate_detection_reliability_report(
+            result, report_dir=str(tmp_path),
+        )
+        with open(tex_path) as f:
+            content = f.read()
+        assert "AudioSeal" in content
+        assert "GaussianNoise" in content
+        assert "85.00" in content
+        assert "Audio Distortion" in content
+
+    def test_generates_with_quality_metrics(self, tmp_path):
+        result = {
+            "model_name": "PerthModel",
+            "is_zero_bit": True,
+            "detection_threshold": None,
+            "n_files": 3,
+            "no_attack": {
+                "false_positive_count": 0,
+                "false_negative_count": 0,
+                "metrics": {"pesq": 4.1, "stoi": 0.98, "visqol": 4.5},
+            },
+            "attacks": {},
+        }
+        tex_path = generate_detection_reliability_report(
+            result, report_dir=str(tmp_path),
+        )
+        with open(tex_path) as f:
+            content = f.read()
+        assert "Watermarked Audio Quality" in content
+        assert "4.10" in content

--- a/tests/test_detection_reliability.py
+++ b/tests/test_detection_reliability.py
@@ -5,7 +5,6 @@ import pytest
 
 from utils.detection_reliability import (
     _detect,
-    _detect_is_positive_zero_bit,
     run_detection_reliability,
 )
 from utils.detection_reliability_report_generator import (
@@ -18,37 +17,8 @@ from utils.detection_reliability_report_generator import (
 )
 
 
-class TestDetectIsPositiveZeroBit:
-    def test_scalar_true(self):
-        assert _detect_is_positive_zero_bit(1) is True
-
-    def test_scalar_false(self):
-        assert _detect_is_positive_zero_bit(0) is False
-
-    def test_numpy_array_positive(self):
-        assert _detect_is_positive_zero_bit(np.array(1)) is True
-
-    def test_numpy_array_zero(self):
-        assert _detect_is_positive_zero_bit(np.array(0)) is False
-
-    def test_list_positive(self):
-        assert _detect_is_positive_zero_bit([1]) is True
-
-    def test_list_zero(self):
-        assert _detect_is_positive_zero_bit([0]) is False
-
-    def test_empty_list(self):
-        assert _detect_is_positive_zero_bit([]) is False
-
-    def test_numpy_array_1d(self):
-        assert _detect_is_positive_zero_bit(np.array([1, 0, 1])) is True
-
-    def test_numpy_array_all_zeros(self):
-        assert _detect_is_positive_zero_bit(np.array([0, 0, 0])) is False
-
-
 class TestDetect:
-    """Tests for _detect with mocked models."""
+    """Tests for _detect with mocked models using is_watermarked()."""
 
     class _ZeroBitModel:
         def __init__(self, returns):
@@ -57,37 +27,41 @@ class TestDetect:
         def detect(self, audio, sr):
             return self._returns
 
+        def is_watermarked(self, detect_output):
+            return bool(np.any(detect_output)) if detect_output is not None else False
+
     class _ConfidenceModel:
-        def __init__(self, watermark, confidence):
+        def __init__(self, watermark, confidence, threshold=0.5):
             self._watermark = watermark
             self._confidence = confidence
+            self._threshold = threshold
 
         def detect(self, audio, sr):
             return self._watermark, self._confidence
 
+        def is_watermarked(self, detect_output):
+            _wm, conf = detect_output
+            return float(conf) >= self._threshold
+
     def test_zero_bit_positive(self):
         model = self._ZeroBitModel(np.array(1))
-        assert _detect(model, np.zeros(100), 16000, False) is True
+        assert _detect(model, np.zeros(100), 16000) is True
 
     def test_zero_bit_negative(self):
         model = self._ZeroBitModel(np.array(0))
-        assert _detect(model, np.zeros(100), 16000, False) is False
+        assert _detect(model, np.zeros(100), 16000) is False
 
     def test_confidence_above_threshold(self):
-        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.8)
-        assert _detect(model, np.zeros(100), 16000, True, 0.5) is True
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.8, threshold=0.5)
+        assert _detect(model, np.zeros(100), 16000) is True
 
     def test_confidence_below_threshold(self):
-        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.3)
-        assert _detect(model, np.zeros(100), 16000, True, 0.5) is False
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.3, threshold=0.5)
+        assert _detect(model, np.zeros(100), 16000) is False
 
     def test_confidence_at_threshold(self):
-        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.5)
-        assert _detect(model, np.zeros(100), 16000, True, 0.5) is True
-
-    def test_confidence_no_threshold_falls_back_to_zero_bit(self):
-        model = self._ConfidenceModel(np.array([0]), 0.9)
-        assert _detect(model, np.zeros(100), 16000, True, None) is False
+        model = self._ConfidenceModel(np.array([1, 0, 1]), 0.5, threshold=0.5)
+        assert _detect(model, np.zeros(100), 16000) is True
 
 
 class TestFormatHelpers:
@@ -134,10 +108,7 @@ class TestFormatHelpers:
 class TestRunDetectionReliability:
     """Integration tests with a mocked benchmark."""
 
-    class _MockModel:
-        def __init__(self, is_zero_bit=True):
-            self._is_zero_bit = is_zero_bit
-
+    class _MockZeroBitModel:
         def generate_watermark(self):
             return np.array([1, 0, 1, 0])
 
@@ -145,21 +116,44 @@ class TestRunDetectionReliability:
             return audio + 0.001
 
         def detect(self, audio, sampling_rate):
-            if self._is_zero_bit:
-                return np.array(1)
+            return np.array(1)
+
+        def is_watermarked(self, detect_output):
+            return bool(np.any(detect_output)) if detect_output is not None else False
+
+    class _MockConfidenceModel:
+        def generate_watermark(self):
+            return np.array([1, 0, 1, 0])
+
+        def embed(self, audio, watermark_data, sampling_rate):
+            return audio + 0.001
+
+        def detect(self, audio, sampling_rate):
             return np.array([1, 0, 1, 0]), 0.8
+
+        def is_watermarked(self, detect_output):
+            _wm, confidence = detect_output
+            return float(confidence) >= 0.5
+
+    class _MockUnsupportedModel:
+        def generate_watermark(self):
+            return np.array([1, 0, 1, 0])
+
+        def embed(self, audio, watermark_data, sampling_rate):
+            return audio + 0.001
+
+        def detect(self, audio, sampling_rate):
+            return np.array([1, 0, 1, 0])
 
     class _MockBenchmark:
         ALWAYS_ON_METRICS = ("pesq", "visqol", "stoi")
 
-        def __init__(self, is_zero_bit=True, returns_confidence=False,
-                     detection_threshold=None):
+        def __init__(self, model_cls, is_zero_bit=True, detection_threshold=None):
             self.models = {
                 "TestModel": {
-                    "class": lambda: TestRunDetectionReliability._MockModel(is_zero_bit),
+                    "class": model_cls,
                     "config": {
                         "is_zero_bit": is_zero_bit,
-                        "returns_confidence": returns_confidence,
                         "detection_threshold": detection_threshold,
                         "sampling_rate": 16000,
                     },
@@ -174,7 +168,9 @@ class TestRunDetectionReliability:
         audio = np.sin(np.linspace(0, 1, sr)).astype(np.float32)
         sf.write(str(audio_file), audio, sr)
 
-        benchmark = self._MockBenchmark(is_zero_bit=True)
+        benchmark = self._MockBenchmark(
+            model_cls=self._MockZeroBitModel, is_zero_bit=True,
+        )
         result = run_detection_reliability(
             benchmark, [str(audio_file)], "TestModel",
         )
@@ -193,8 +189,8 @@ class TestRunDetectionReliability:
         sf.write(str(audio_file), audio, sr)
 
         benchmark = self._MockBenchmark(
-            is_zero_bit=False, returns_confidence=True,
-            detection_threshold=0.5,
+            model_cls=self._MockConfidenceModel,
+            is_zero_bit=False, detection_threshold=0.5,
         )
         result = run_detection_reliability(
             benchmark, [str(audio_file)], "TestModel",
@@ -211,29 +207,16 @@ class TestRunDetectionReliability:
         sf.write(str(audio_file), np.zeros(16000), 16000)
 
         benchmark = self._MockBenchmark(
-            is_zero_bit=False, returns_confidence=False,
+            model_cls=self._MockUnsupportedModel,
+            is_zero_bit=False,
         )
-        with pytest.raises(ValueError, match="requires either"):
-            run_detection_reliability(
-                benchmark, [str(audio_file)], "TestModel",
-            )
-
-    def test_rejects_confidence_without_threshold(self, tmp_path):
-        audio_file = tmp_path / "test.wav"
-        import soundfile as sf
-        sf.write(str(audio_file), np.zeros(16000), 16000)
-
-        benchmark = self._MockBenchmark(
-            is_zero_bit=False, returns_confidence=True,
-            detection_threshold=None,
-        )
-        with pytest.raises(ValueError, match="detection_threshold"):
+        with pytest.raises(ValueError, match="does not implement is_watermarked"):
             run_detection_reliability(
                 benchmark, [str(audio_file)], "TestModel",
             )
 
     def test_model_not_found(self):
-        benchmark = self._MockBenchmark()
+        benchmark = self._MockBenchmark(model_cls=self._MockZeroBitModel)
         with pytest.raises(ValueError, match="not found"):
             run_detection_reliability(
                 benchmark, ["fake.wav"], "NonExistentModel",


### PR DESCRIPTION
## Summary

- Add `--detection_reliability` CLI flag that measures false positive and false negative rates for watermark detection
- Support both zero-bit models (Perth) and confidence-based models (AudioSeal, AWARE) using configurable `detection_threshold` in model config.json
- Generate grouped LaTeX/PDF report: per-attack accuracy + FP/FN rates, with always-on metrics (PESQ, ViSQOL, STOI) or full group-specific metrics when `--calculate_quality_metrics` is set
- Combinable with `--no_attacks` (generates both no-attacks and reliability reports), `--save_audio` (saves watermarked and attacked audio), and `--attack_groups`/`--attack_types`

## Changes

- **src/utils/detection_reliability.py** — core FP/FN measurement logic supporting zero-bit and confidence threshold detection
- **src/utils/detection_reliability_report_generator.py** — LaTeX report grouped by attack category (mirrors detailed report structure)
- **src/run.py** — new `--detection_reliability` CLI argument, dispatch logic, combined mode with `--no_attacks`
- **src/plugins/models/audio_seal/config.json** — added `detection_threshold: 0.5`
- **src/plugins/models/aware/config.json** — added `detection_threshold: 0.5`
- **tests/test_detection_reliability.py** — 36 unit tests covering detection helpers, report generation, and integration
- **.gitignore** — added dataset folders (chinese-test, chinese-test-60s, chinese-test-combined, report_baseline_replacement)


