### PR TITLE
Add Codec2 vocoder attack with multi-bitrate support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ metrics_testing_samples/
 checkpoints/
 audio_processed/
 samples-148/
-<<<<<<< Updated upstream
 rezultati/
 weights/
 report_examples/
@@ -41,13 +40,8 @@ chinese-test/
 chinese-test-60s/
 chinese-test-combined/
 report_baseline_replacement/
-CHANGELOG_DPM-1576.md
-CODE_EXPLANATION.md
-benchmark.md
-=======
-trump/
-weights/
->>>>>>> Stashed changes
+results/
+scripts/
 
 
 report/

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ covers. Groups can be combined with `--attack_types` to add individual attacks.
 | Tag | Attacks |
 |-----|---------|
 | `process_disruption` | `CrossModelAttack`, `CollusionAttack`, `ZeroBitCollusionAttack`, `Collusion2Attack`, `SameModelAttack` |
-| `audio_editing` | `CutSamplesAttack`, `CropBeginningAttack`, `CropRandomAttack`, `WaveletAttack`, `LowpassFilterAttack`, `HighpassFilterAttack`, `BandstopFilterAttack`, `SmoothingAttack`, `ChorusAttack`, `FlangerAttack`, `EchoAttack`, `EqualizerAttack`, `QuantizationAttack`, `STFTQuantizationAttack`, `PCMQuantizationAttack`, `Mp3CompressionAttack`, `EncodecAttack`, `DescriptAudioCodecAttack`, `OpusCodecAttack`, `ResamplingPolyAttack`, `MixingAttack` |
+| `audio_editing` | `CutSamplesAttack`, `CropBeginningAttack`, `CropRandomAttack`, `WaveletAttack`, `LowpassFilterAttack`, `HighpassFilterAttack`, `BandstopFilterAttack`, `SmoothingAttack`, `ChorusAttack`, `FlangerAttack`, `EchoAttack`, `EqualizerAttack`, `QuantizationAttack`, `STFTQuantizationAttack`, `PCMQuantizationAttack`, `Mp3CompressionAttack`, `EncodecAttack`, `DescriptAudioCodecAttack`, `OpusCodecAttack`, `Codec2VocoderAttack`, `ResamplingPolyAttack`, `MixingAttack` |
 | `audio_distortion` | `GaussianNoiseAttack`, `PinkNoiseAttack`, `SignInversionAttack`, `LPCAttack` |
 | `desynchronization` | `TimeStretchAttack`, `PitchShiftAttack`, `InvertedTimeStretchAttack`, `ZeroCrossInsertsAttack`, `FlipSamplesAttack`, `ReplacementAttack`, `Replacement2Attack` |
 | `ai_attacks` | `SpeechEnhancement1Attack`, `SpeechEnhancement2Attack`, `SpeechTokenizationAttack`, `NeuralVocoderAttack`, `DiffusionAttack` |
@@ -156,6 +156,28 @@ covers. Groups can be combined with `--attack_types` to add individual attacks.
 Attacks not listed in any group fall under "Other Attacks" in the detailed
 report. The canonical mapping lives in `src/utils/attack_groups.py` — update it
 there when adding a new attack so the reports pick the right metrics for it.
+
+**Codec2 Vocoder Attack:**
+
+`Codec2VocoderAttack` simulates transmission through a low-bitrate voice channel
+(similar to MELP/MELPe military vocoders). It encodes audio at a given bitrate
+using the Codec2 codec and decodes it back to PCM. The `bitrate_codec2` parameter
+in `config.json` accepts either a single value or a list of bitrates:
+
+```json
+{"bitrate_codec2": [700, 1200, 2400]}
+```
+
+When a list is provided, the benchmark automatically expands it into separate
+runs — one per bitrate — and reports results as `Codec2VocoderAttack_700`,
+`Codec2VocoderAttack_1200`, etc. Supported bitrates: 700, 1200, 1300, 1400,
+1600, 2400, 3200 bps. Unsupported values are skipped with a warning.
+
+> **Attack naming convention:** Attack class names must not contain underscores.
+> The benchmark uses underscores as a separator between the base attack name and
+> a parameter suffix (e.g. `Codec2VocoderAttack_700`). If an attack name contains
+> an underscore, the group lookup will incorrectly treat the part after the last
+> underscore as a suffix.
 
 ### 3. Quality Metrics (Optional)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,3 +75,4 @@ visqol-python==3.4.0
 encodec==0.1.1
 descript-audio-codec==1.0.0
 audiocomplib==0.2.0
+pycodec2>=4.0.0

--- a/src/benchmark.py
+++ b/src/benchmark.py
@@ -235,6 +235,35 @@ class Benchmark:
 
         # If user doesn't specify attacks, use them all
         attack_types = attack_types or list(self.attacks.keys())
+
+        # Expand attacks whose config has a bitrate list into separate entries.
+        # E.g. Codec2VocoderAttack with bitrate_codec2=[700,1300,2400] becomes
+        # three entries: Codec2VocoderAttack_700, Codec2VocoderAttack_1300, ...
+        expanded_attacks = []
+        for atk_name in attack_types:
+            if atk_name not in self.attacks:
+                expanded_attacks.append((atk_name, atk_name, {}))
+                continue
+            config = self.attacks[atk_name].get("config") or {}
+            bitrate_key = next(
+                (k for k in config if k == "bitrate_codec2" and isinstance(config[k], list)),
+                None,
+            )
+            if bitrate_key:
+                _CODEC2_SUPPORTED = {700, 1200, 1300, 1400, 1600, 2400, 3200}
+                for val in config[bitrate_key]:
+                    if val not in _CODEC2_SUPPORTED:
+                        logger.warning(
+                            f"Skipping unsupported Codec2 bitrate: {val}. "
+                            f"Supported: {sorted(_CODEC2_SUPPORTED)}"
+                        )
+                        continue
+                    expanded_attacks.append(
+                        (atk_name, f"{atk_name}_{val}", {bitrate_key: val})
+                    )
+            else:
+                expanded_attacks.append((atk_name, atk_name, {}))
+
         results = {}
 
         if wm_model not in self.models:
@@ -329,17 +358,21 @@ class Benchmark:
             )
 
             # Apply each attack and compute metrics
-            for attack_name in attack_types:
-                if attack_name not in self.attacks:
-                    logger.warning(f"Attack '{attack_name}' not found. Skipping.")
+            for attack_class_name, attack_display_name, attack_overrides in expanded_attacks:
+                if attack_class_name not in self.attacks:
+                    logger.warning(f"Attack '{attack_class_name}' not found. Skipping.")
                     continue
 
                 if verbose:
-                    logger.info(f"  Applying attack: {attack_name}")
+                    logger.info(f"  Applying attack: {attack_display_name}")
 
-                attack_instance = self.attacks[attack_name]["class"]()
+                attack_instance = self.attacks[attack_class_name]["class"]()
+                attack_name = attack_display_name
 
-                if (attack_name =="CrossModelAttack"):
+                # Merge bitrate overrides into kwargs for this attack
+                current_attack_kwargs = {**attack_kwargs, **attack_overrides}
+
+                if (attack_class_name == "CrossModelAttack"):
 
                     different_model_name = kwargs.get("different_model_name_cross_model")
                     logger.info(f"Different model is chosen and it's {different_model_name}")
@@ -347,21 +380,21 @@ class Benchmark:
                     different_model_instance = different_model_cls()
 
                     attacked_audio, different_watermark = attack_instance.apply(
-                        watermarked_audio, **attack_kwargs
+                        watermarked_audio, **current_attack_kwargs
                     )
 
                 #in case of the collusion mod attack
-                elif (attack_name == "ZeroBitCollusionAttack"):
+                elif (attack_class_name == "ZeroBitCollusionAttack"):
 
-                    attack_kwargs["original_audio_collusion"] = audio
+                    current_attack_kwargs["original_audio_collusion"] = audio
 
                     attacked_audio = attack_instance.apply(
-                        watermarked_audio, **attack_kwargs
+                        watermarked_audio, **current_attack_kwargs
                     )
 
                 else:
                     attacked_audio = attack_instance.apply(
-                        watermarked_audio, **attack_kwargs
+                        watermarked_audio, **current_attack_kwargs
                     )
 
                 # Ensure consistent shape for all attacks

--- a/src/plugins/attacks/codec2_vocoder/attack.py
+++ b/src/plugins/attacks/codec2_vocoder/attack.py
@@ -1,0 +1,77 @@
+import logging
+
+import numpy as np
+import pycodec2
+
+from core.base_attack import BaseAttack
+from utils.utils import resample_audio
+
+logger = logging.getLogger(__name__)
+
+CODEC2_SAMPLE_RATE = 8000
+SUPPORTED_BITRATES = {700, 1200, 1300, 1400, 1600, 2400, 3200}
+
+
+class Codec2VocoderAttack(BaseAttack):
+    """Low-bitrate parametric vocoder attack using Codec2.
+
+    Encodes audio at a specified bitrate (700-3200 bps) then decodes back
+    to PCM. This simulates transmission through a low-bitrate voice channel
+    (similar to MELP/MELPe military vocoders).
+
+    Codec2 requires 8kHz mono input, so the attack resamples internally.
+    """
+
+    def apply(self, audio: np.ndarray, **kwargs) -> np.ndarray:
+        sampling_rate = kwargs.get("sampling_rate", 16000)
+        bitrate = kwargs.get("bitrate_codec2", 1300)
+
+        if isinstance(bitrate, list):
+            bitrate = bitrate[0]
+
+        if bitrate not in SUPPORTED_BITRATES:
+            logger.warning(
+                f"Codec2 bitrate {bitrate} not supported. "
+                f"Supported: {sorted(SUPPORTED_BITRATES)}. Returning audio unchanged."
+            )
+            return audio
+
+        if sampling_rate != CODEC2_SAMPLE_RATE:
+            audio_8k = resample_audio(audio, sampling_rate, CODEC2_SAMPLE_RATE)
+        else:
+            audio_8k = audio
+
+        audio_8k = np.clip(audio_8k, -1.0, 1.0)
+        audio_int16 = (audio_8k * 32767).astype(np.int16)
+
+        codec = pycodec2.Codec2(bitrate)
+        samples_per_frame = codec.samples_per_frame()
+
+        # Pad to multiple of frame size
+        n_samples = len(audio_int16)
+        remainder = n_samples % samples_per_frame
+        if remainder != 0:
+            pad_len = samples_per_frame - remainder
+            audio_int16 = np.pad(audio_int16, (0, pad_len), mode='constant')
+
+        # Encode then decode frame by frame
+        decoded_frames = []
+        for i in range(0, len(audio_int16), samples_per_frame):
+            frame = audio_int16[i:i + samples_per_frame]
+            encoded = codec.encode(frame)
+            decoded = codec.decode(encoded)
+            decoded_frames.append(decoded)
+
+        decoded_audio = np.concatenate(decoded_frames)[:n_samples]
+        decoded_float = decoded_audio.astype(np.float32) / 32767.0
+
+        if sampling_rate != CODEC2_SAMPLE_RATE:
+            decoded_float = resample_audio(decoded_float, CODEC2_SAMPLE_RATE, sampling_rate)
+
+        # Match original length
+        if len(decoded_float) > len(audio):
+            decoded_float = decoded_float[:len(audio)]
+        elif len(decoded_float) < len(audio):
+            decoded_float = np.pad(decoded_float, (0, len(audio) - len(decoded_float)))
+
+        return decoded_float

--- a/src/plugins/attacks/codec2_vocoder/config.json
+++ b/src/plugins/attacks/codec2_vocoder/config.json
@@ -1,0 +1,4 @@
+{
+    "_comment": "Supported bitrates: 700, 1200, 1300, 1400, 1600, 2400, 3200. Single value or list.",
+    "bitrate_codec2": [700,1200,2400]
+}

--- a/src/utils/attack_groups.py
+++ b/src/utils/attack_groups.py
@@ -48,6 +48,7 @@ ATTACK_GROUPS = {
             "EncodecAttack",
             "DescriptAudioCodecAttack",
             "OpusCodecAttack",
+            "Codec2VocoderAttack",
             "ResamplingPolyAttack",
             "MixingAttack",
         ],
@@ -149,10 +150,20 @@ def get_attacks_for_groups(group_names):
 
 
 def get_group_for_attack(attack_name):
-    """Return the group key for a given attack name, or None."""
+    """Return the group key for a given attack name, or None.
+
+    Handles expanded names like Codec2VocoderAttack_700 by stripping
+    the trailing _<number> suffix when no exact match is found.
+    """
     for group_key, group in ATTACK_GROUPS.items():
         if attack_name in group["attacks"]:
             return group_key
+    # Try stripping bitrate suffix (e.g. Codec2VocoderAttack_700 -> Codec2VocoderAttack)
+    base_name = "_".join(attack_name.rsplit("_", 1)[:-1]) if "_" in attack_name else None
+    if base_name:
+        for group_key, group in ATTACK_GROUPS.items():
+            if base_name in group["attacks"]:
+                return group_key
     return None
 
 

--- a/src/utils/detailed_report_generator.py
+++ b/src/utils/detailed_report_generator.py
@@ -104,6 +104,7 @@ AUDIO_EDITING_SUBGROUPS = {
             "EncodecAttack",
             "DescriptAudioCodecAttack",
             "OpusCodecAttack",
+            "Codec2VocoderAttack",
             "ResamplingPolyAttack",
         ],
         "quality_metrics": ["pesq", "psnr", "mcd", "visqol"],
@@ -433,10 +434,11 @@ class DetailedReportGenerator:
 
         # Sub-sections
         for sub_key, sub_info in AUDIO_EDITING_SUBGROUPS.items():
-            sub_attacks = [
-                a for a in sub_info["attacks"]
-                if a in aggregated["attacks"]
-            ]
+            sub_attacks = []
+            for base_name in sub_info["attacks"]:
+                for result_name in aggregated["attacks"]:
+                    if result_name == base_name or result_name.startswith(base_name + "_"):
+                        sub_attacks.append(result_name)
             if not sub_attacks:
                 continue
 

--- a/src/utils/latex_helpers.py
+++ b/src/utils/latex_helpers.py
@@ -86,6 +86,7 @@ def display_attack_name(attack_name: str, split_camel_case: bool = False) -> str
     ``L P C``.
     """
     stripped = attack_name.replace("Attack", "").strip()
+    stripped = stripped.replace("_", "\\_")
     if not split_camel_case:
         return stripped
 


### PR DESCRIPTION
Summary:

-Add Codec2 low-bitrate vocoder attack (simulates MELP-like military voice channel)
-Supports multiple bitrates: 700, 1200, 1300, 1400, 1600, 2400, 3200 bps
-Multi-bitrate config: when bitrate_codec2 is a list, benchmark expands into separate runs per value
-Unsupported bitrate values are skipped with a warning
-Attack registered in audio_editing group under Compression & Quantization
-Fix LaTeX subscript rendering for attack names containing underscores
-Fix detailed report not showing metrics for expanded attack names